### PR TITLE
[FIX][13.0] v13_fix_web_responsive: fix preview image, pdf, video on phone

### DIFF
--- a/viin_brand_common/static/src/scss/web_responsive.scss
+++ b/viin_brand_common/static/src/scss/web_responsive.scss
@@ -1,0 +1,7 @@
+// Document Viewer
+.o_web_client.o_chatter_position_sided {
+    .o_modal_fullscreen.o_document_viewer {
+        // On-top of navbar
+        z-index: 1052!important;
+    }
+}

--- a/viin_brand_common/views/assets.xml
+++ b/viin_brand_common/views/assets.xml
@@ -73,6 +73,10 @@
 				<link rel="stylesheet" type="text/scss"
 					href="/viin_brand_common/static/src/scss/base_settings.scss" />
 			</xpath>
+			<xpath expr=".">
+				<link rel="stylesheet" type="text/scss"
+					href="/viin_brand_common/static/src/scss/web_responsive.scss" />
+			</xpath>
 		</template>
 	</data>
 </odoo>


### PR DESCRIPTION
Vì z-index của o_document_viewer (10) nhỏ hơn z-index của cửa sổ chat (1051) nên trên mobile app image, pdf, video hiển thị xuống dưới cửa sổ chat, người dùng sẽ không nhìn thấy image, pdf, video.
Link ticket: https://viindoo.com/web#active_id=792&cids=1&id=792&model=helpdesk.ticket&menu_id=