### PR TITLE
[IMP][14.0] viin_brand_pos: change order number background color

### DIFF
--- a/viin_brand_pos/static/src/scss/style.scss
+++ b/viin_brand_pos/static/src/scss/style.scss
@@ -76,3 +76,7 @@
 .payment-screen .paymentlines-empty .total{
     color: $success;
 }
+
+[badge]:after{
+    background: $primary;
+}


### PR DESCRIPTION
Task: [POS theme](https://viindoo.com/web#id=4607&model=helpdesk.ticket&view_type=form&cids=1&menu_id=89)

- Thay đổi màu background của order number 

Before
<img width="255" alt="Screenshot_9" src="https://user-images.githubusercontent.com/90305443/151100702-2c2e9d51-f4f5-4f6d-8f89-52edf707f27f.png">



After
![Screenshot from 2022-01-26 10-29-30](https://user-images.githubusercontent.com/90305443/151099718-3fb9d12f-044c-4f76-8d53-23cc76c42d6c.png)

