### PR TITLE
[IMP][14.0] viin_brand_website: Fix module's url in website/info to landing page

### DIFF
--- a/viin_brand_website/__init__.py
+++ b/viin_brand_website/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/viin_brand_website/models/__init__.py
+++ b/viin_brand_website/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_module

--- a/viin_brand_website/models/ir_module.py
+++ b/viin_brand_website/models/ir_module.py
@@ -1,0 +1,42 @@
+from odoo import models
+from odoo.addons.http_routing.models.ir_http import slugify
+
+
+
+class Module(models.Model):
+    _inherit = 'ir.module.module'
+    
+    def make_url(self):
+        """
+        Convert module's name to compatible string for web url
+        E.g: Discuss=> discuss
+        Live Chat => live-chat
+        Accounting & Finance => accounting-finance
+        """
+        self.ensure_one()
+        module_name_url = slugify(self.shortdesc)
+
+        #set value for exist landing page viindoo
+        if module_name_url == 'accounting-finance':
+            module_name_url = 'accounting'
+        if module_name_url == 'contacts':
+            module_name_url = 'contact'
+        if module_name_url == 'surveys':
+            module_name_url = 'survey'
+        if module_name_url == 'manufacturing':
+            module_name_url = 'mrp'
+        if module_name_url == 'elearning':
+            module_name_url = 'e-learning'
+        if module_name_url == 'events':
+            module_name_url = 'event'
+        if module_name_url == 'expenses':
+            module_name_url = 'expense'
+        if module_name_url == 'point-of-sale':
+            module_name_url = 'pos'
+        if module_name_url == 'forum':
+            module_name_url = 'app-forum'
+        if module_name_url == 'meal-orders':
+            module_name_url = 'hr-meal'
+        if module_name_url == 'repairs':
+            module_name_url = 'repair'
+        return module_name_url

--- a/viin_brand_website/views/templates.xml
+++ b/viin_brand_website/views/templates.xml
@@ -15,5 +15,65 @@
                 </t>
             </xpath>
         </template>
+        
+        <!--Show Website Info 
+            override template to adding some id tags
+        -->
+        <template id="show_website_info"
+            inherit_id="website.show_website_info">
+            <xpath expr="//section[hasclass('container')]" position="replace">
+                <section class="container">
+	                <t t-if="not version">
+	                    <meta http-equiv="refresh" content="0;URL='/website/info'" />
+	                </t>
+	                <t t-if="version">
+	                    <h1><t t-esc="res_company.name"/>
+	                        <small>Odoo Version <t t-raw="version.get('server_version')"/></small>
+	                    </h1>
+	                    <p>
+	                        Information about the <t t-esc="res_company.name"/> instance of <a target="_blank" href="https://www.viindoo.com">Viindoo</a>.
+	                    </p>
+	
+	                    <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_publisher" role="status">
+	                       <button type="button" class="close" data-dismiss="alert" aria-label="Close">×</button>
+	                       <p>
+	                         Note: To hide this page, uncheck it from the top Customize menu.
+	                       </p>
+	                    </div>
+	                    <h2>Installed Applications</h2>
+	                    <dl class="dl-horizontal" t-foreach="apps" t-as="app" id="non_l10n_app">
+	                        <dt id="url_non_l10n_app">
+	                            <a t-attf-href="https://www.viindoo.com/intro/#{app.make_url()}"
+	                               >
+	                               <t t-raw="app.shortdesc"/></a>
+<!-- 	                            <a href="https://www.viindoo.com" t-if="not app.website"><t t-raw="app.shortdesc"/></a> -->
+	                        </dt>
+	                        <dd>
+	                            <span t-raw="app.summary"/>
+	                        </dd><dd class="text-muted" groups='base.group_no_one'>
+	                            Technical name: <span t-field="app.name"/>, author: <span t-field="app.author"/>
+	                        </dd>
+	                    </dl>
+	
+	                    <div t-if="l10n">
+	                        <h2 class='mt32'>Installed Localizations / Account Charts</h2>
+	                        <dl class="dl-horizontal" t-foreach="l10n" t-as="app" id="l10n_app">
+	                            <dt id="url_l10n_app">
+	                                <a t-attf-href="https://www.viindoo.com/intro/accounting">
+	                                    <t t-raw="app.shortdesc"/>
+	                                </a>
+	                            </dt>
+	                            <dd>
+	                                <span t-raw="app.summary"/>
+	                            </dd>
+	                            <dd class="text-muted" groups='base.group_no_one'>
+	                                Technical name: <span t-field="app.name"/>, author: <span t-field="app.author"/>
+	                            </dd>
+	                        </dl>
+	                    </div>
+	                </t>
+                </section>
+            </xpath>
+        </template>
     </data>
 </odoo>


### PR DESCRIPTION
Following to ticket: [https://viindoo.com/web#active_id=15403&cids=1&id=15403&model=project.task&menu_id=](https://viindoo.com/web#active_id=15403&cids=1&id=15403&model=project.task&menu_id=)

- [x]  Fix template for link to exist landing pages

- [x]  Hiện tại một các landing page đã có SEO ranking tuy nhiên `url` của các page này đang đặt tên khác với template nên sẽ cần phải điều hướng link mới được tạo từ template tới các landing page đã có.