### PR TITLE
[IMP][14.0] viin_brand_website: redirect to Viindoo documentation

### DIFF
--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -45,8 +45,11 @@ Editions Supported
     'data': [
         # 'security/ir.model.access.csv',
         'views/templates.xml',
+        'views/res_config_settings_views.xml'
     ],
-
+    'qweb': [
+        'static/src/xml/website_backend.xml',
+        ],
     'images': [
     	# 'static/description/main_screenshot.png'
     	],

--- a/viin_brand_website/static/src/xml/website_backend.xml
+++ b/viin_brand_website/static/src/xml/website_backend.xml
@@ -1,0 +1,17 @@
+<templates id="template" xml:space="preserve">
+   <t t-name="ga_dialog_content" t-inherit="website.ga_dialog_content"
+        t-inherit-mode="extension">
+		<xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/websites/website/optimize/google_analytics.html']"
+		position="attributes">
+		    <attribute name="href">
+		    https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-google-analytics.html
+		    </attribute>
+		</xpath>
+		<xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/websites/website/optimize/google_analytics_dashboard.html']"
+		position="attributes">
+		    <attribute name="href">
+		    https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html
+		    </attribute>
+		</xpath>
+	</t>
+</templates>

--- a/viin_brand_website/views/res_config_settings_views.xml
+++ b/viin_brand_website/views/res_config_settings_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+	    <field name="name">res.config.settings.view.form</field>
+	    <field name="model">res.config.settings</field>
+	    <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='seo_settings']/div/div/div/a[hasclass('oe_link')]"
+            position="attributes">
+                <attribute name="href">
+                https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-google-analytics.html
+                </attribute>
+            </xpath>
+            <xpath expr="//div[@id='google_analytics_dashboard_setting']/div/div/a[hasclass('oe_link')]"
+            position="attributes">
+                <attribute name="href">
+                https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Following ticket: 
 - [https://viindoo.com/web#id=5332&model=helpdesk.ticket&view_type=form&cids=1&menu_id=89](https://viindoo.com/web#id=5332&model=helpdesk.ticket&view_type=form&cids=1&menu_id=89)
 - https://viindoo.com/web#cids=1&id=5393&model=helpdesk.ticket&menu_id=

- Redirect odoo link to Viindoo's Documentation