### PR TITLE
[IMP][14.0] viin_brand_website: redirect l10n app and COA to Viindoo

### DIFF
--- a/viin_brand_website/views/website_templates.xml
+++ b/viin_brand_website/views/website_templates.xml
@@ -8,5 +8,9 @@
         <xpath expr="//t[@t-if='version']/p" position="replace">
             <p>Information about the <a target="_blank" href="https://about.viindoo.com">Viindoo JSC Company.</a></p>
         </xpath>
+        <!-- Chart of account and l10n app -->
+        <xpath expr="//div[@t-if='l10n']/dl/dt/a" position="attributes">
+            <attribute name="t-attf-href">https://viindoo.com/intro/accounting</attribute>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
References to ticket: https://viindoo.com/web#id=15403&model=project.task&view_type=form&cids=1&menu_id=89

- Hiện tại, các app l10n và COA chưa có landing page, một số app l10n không có trên app store (như l10n_vn, l10n_multilang) nên phương án dẫn link toàn bộ các app về app store không khả thi. 
- Pr này sẽ điều hướng toàn bộ các app trên về landing page của phân hệ kế toán: https://viindoo.com/intro/accounting