### PR TITLE
[IMP][14.0] viin_brand_website: using `replace` instead of conditional

### DIFF
--- a/viin_brand_website/static/src/js/dialog.js
+++ b/viin_brand_website/static/src/js/dialog.js
@@ -1,14 +1,12 @@
 odoo.define('viin_brand_website.Dialog', function(require) {
 	"use strict";
 	var Dialog = require('web.Dialog');
-	var core = require('web.core');
-	var _t = core._t;
 
 	Dialog.include({
 
 		init: function (parent, options) {
 			this._super(...arguments);
-			this.title = this.title == _t('Odoo') ? _t('Viindoo') : this.title;
+			this.title = this.title.replace(/Odoo/g,'Viindoo');
 	    }
 	});
 	return Dialog;


### PR DESCRIPTION
Using `replace` instead of conditional to cover the scenario: Dialog's Title contains one or more `Odoo` keywords