### PR TITLE
[IMP][14.0]viin_brand_website_slides: add attribute nofollow for link

### DIFF
--- a/viin_brand_website_slides/__manifest__.py
+++ b/viin_brand_website_slides/__manifest__.py
@@ -45,6 +45,7 @@ Editions Supported
     'data': [
         # 'security/ir.model.access.csv',
         'views/slide_slide_views.xml',
+        'views/website_slides_templates_lesson.xml'
     ],
 
     'images': [

--- a/viin_brand_website_slides/views/website_slides_templates_lesson.xml
+++ b/viin_brand_website_slides/views/website_slides_templates_lesson.xml
@@ -1,0 +1,7 @@
+<odoo>
+	<template id="slide_content_detailed" inherit_id="website_slides.slide_content_detailed">
+		<xpath expr="//a[@t-if='is_training_channel']" position="attributes">
+			<attribute name="rel">nofollow</attribute>
+		</xpath>
+	</template>
+</odoo>


### PR DESCRIPTION
**PR này**
*Cải tiến: 
Với những liên kết liên quan đến slide ở chế độ toàn màn hình. (VD: https://viindoo.com/slides/slide/tao-va-phan-quyen-nguoi-dung-trong-he-thong-14-0-912?fullscreen=1)  có thể thêm thuộc tính nofollow cho thẻ dẫn tới (Xem ảnh). Vì những liên kết này ở chế độ thường là đủ cho SEO bot. 

Ticket: [#27981](https://viindoo.com/web#id=27981&model=project.task&view_type=form&cids=1&menu_id=)

![Selection_014](https://user-images.githubusercontent.com/12383306/174778317-a06c66a6-9351-41db-ab50-39689e942aff.png)

