### PR TITLE
[14.0][FIX] viin_brand_common: fix link to non-existing documentation page

### DIFF
--- a/viin_brand_common/views/res_users_views.xml
+++ b/viin_brand_common/views/res_users_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">res.users</field>
 	    <field name="inherit_id" ref="base.view_users_form_simple_modif" />
 	    <field name="arch" type="xml">
-	       <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/developer/webservices/odoo.html#api-keys']" position="attributes">
+	       <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/developer/misc/api/external_api.html#api-keys']" position="attributes">
 	           <attribute name="href">https://viindoo.com/documentation/14.0/developer/development/integrate-with-third-party-resources.html</attribute>
 	       </xpath>
 	    </field>


### PR DESCRIPTION
The documentation page for the external API was moved elsewhere with PR
`odoo/documentation#2026`

Depends:

- [ ] https://github.com/Viindoo/odoo/pull/370

