### PR TITLE
[FIX][14.0] viin_brand: fix 404 link in website/info

### DIFF
--- a/viin_brand/apriori.py
+++ b/viin_brand/apriori.py
@@ -12,7 +12,7 @@ modules_website = {
     'hr_expense': 'https://viindoo.com/intro/expense',
     'hr_holidays': 'https://viindoo.com/intro/time-off',
     'hr_recruitment': 'https://viindoo.com/intro/recruitment',
-    'hr_contract': 'https://viindoo.com/en/apps/app/14.0/hr_contract',
+    'hr_contract': 'https://viindoo.com/apps/app/15.0/viin_hr_contract',
     # 'hr_skills': '',
     'im_livechat': 'https://viindoo.com/intro/live-chat',
     # 'lunch': '',

--- a/viin_brand_sale/views/res_config_settings_views.xml
+++ b/viin_brand_sale/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales/products-prices/using-product-variants-in-viindoo.html</attribute>
             </xpath>
             <xpath expr="//div[@id='pricelist_configuration']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/vi/applications/sales/sales/manage-your-pricing/preparing-price-lists-and-specific-discount-policies.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales/manage-your-pricing/manage-advances-price-rules.html</attribute>
             </xpath>
             <xpath expr="//div[@id='sale_config_online_confirmation_sign']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales/send-quotations/activate-e-sign-feature-to-confirm-order.html</attribute>

--- a/viin_brand_website/static/src/xml/website_backend.xml
+++ b/viin_brand_website/static/src/xml/website_backend.xml
@@ -3,11 +3,11 @@
         t-inherit-mode="extension">
 		<xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/websites/website/optimize/google_analytics.html']"
 		position="attributes">
-		    <attribute name="href">https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-google-analytics.html</attribute>
+		    <attribute name="href">https://viindoo.com/documentation/14.0/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-google-analytics.html</attribute>
 		</xpath>
 		<xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/websites/website/optimize/google_analytics_dashboard.html']"
 		position="attributes">
-		    <attribute name="href">https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html</attribute>
+		    <attribute name="href">https://viindoo.com/documentation/14.0/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html</attribute>
 		</xpath>
 	</t>
 </templates>

--- a/viin_brand_website/views/res_config_settings_views.xml
+++ b/viin_brand_website/views/res_config_settings_views.xml
@@ -10,11 +10,11 @@
             </xpath>
             <xpath expr="//div[@id='seo_settings']/div/div/div/a[hasclass('oe_link')]"
             position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-google-analytics.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-google-analytics.html</attribute>
             </xpath>
             <xpath expr="//div[@id='google_analytics_dashboard_setting']/div/div/a[hasclass('oe_link')]"
             position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/vi/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- Sửa lại link đúng trong `/website/info` cho module `hr_contract`
- Xoá các chỉ báo ngôn ngữ khi điều hướng về Viindoo

Ticket: https://viindoo.com/web#id=15403&model=project.task&view_type=form&cids=1&menu_id=89