### PR TITLE
[FIX][14.0]viin_brand_common: upgrade xpath

### DIFF
--- a/viin_brand_common/views/res_users_views.xml
+++ b/viin_brand_common/views/res_users_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">res.users</field>
 	    <field name="inherit_id" ref="base.view_users_form_simple_modif" />
 	    <field name="arch" type="xml">
-	       <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/developer/misc/api/external_api.html#api-keys']" position="attributes">
+	       <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/developer/webservices/odoo.html#api-keys']" position="attributes">
 	           <attribute name="href">https://viindoo.com/documentation/14.0/developer/development/integrate-with-third-party-resources.html</attribute>
 	       </xpath>
 	    </field>


### PR DESCRIPTION
- Odoo thay đổi link dẫn đến khi xpath trực tiếp vào thẻ `<a>` sẽ bị chết link nên cần thay đổi lại xpath