### PR TITLE
[FIX][14.0]viin_brand*: fix link document and change xpath

### DIFF
--- a/viin_brand_auth_oauth/views/res_config_settings_views.xml
+++ b/viin_brand_auth_oauth/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="auth_oauth.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/general/auth/google.html']" position="attributes">
+            <xpath expr="//div/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/websites/website/optimize/how-to-track-your-website-s-traffic-in-viindoo-dashboard.html</attribute>
             </xpath>
         </field>

--- a/viin_brand_auth_totp/views/user_perferences.xml
+++ b/viin_brand_auth_totp/views/user_perferences.xml
@@ -5,8 +5,7 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="auth_totp.view_totp_field" />
         <field name="arch" type="xml">
-            <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/general/auth/2fa.html']"
-            position="attributes">
+            <xpath expr="//group/div/span/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/external-apps-integration/two-factor-authentication.html</attribute>
             </xpath>
         </field>

--- a/viin_brand_base_setup/views/res_config_settings_views.xml
+++ b/viin_brand_base_setup/views/res_config_settings_views.xml
@@ -6,12 +6,12 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='active_user_setting']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/user-account-setting-and-management.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/manage-users/user-account-setting-and-management.html</attribute>
             </xpath>
             <xpath expr="//div[@id='allow_import']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/guiding-to-import-and-export-data.html</attribute>
             </xpath>
-            <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/general/calendars/google/google_calendar_credentials.html']" position="attributes">
+            <xpath expr="//div[@id='sync_google_calendar_setting']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/productivity/calendar/sychronization-with-google-s-calendar.html</attribute>
             </xpath>
             <xpath expr="//div[@name='auth_ldap_right_pane']/a" position="attributes">

--- a/viin_brand_common/views/res_users_views.xml
+++ b/viin_brand_common/views/res_users_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">res.users</field>
 	    <field name="inherit_id" ref="base.view_users_form_simple_modif" />
 	    <field name="arch" type="xml">
-	       <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/developer/misc/api/external_api.html#api-keys']" position="attributes">
+	       <xpath expr="//page/group/a" position="attributes">
 	           <attribute name="href">https://viindoo.com/documentation/14.0/developer/development/integrate-with-third-party-resources.html</attribute>
 	       </xpath>
 	    </field>

--- a/viin_brand_google_calendar/views/res_config_settings_views.xml
+++ b/viin_brand_google_calendar/views/res_config_settings_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">res.config.settings</field>
 	    <field name="inherit_id" ref="google_calendar.res_config_settings_view_form"/>
 	    <field name="arch" type="xml">
-	       <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/general/calendars/google/google_calendar_credentials.html']" position="attributes">
+	       <xpath expr="//div/a" position="attributes">
 	           <attribute name="href">https://viindoo.com/documentation/14.0/applications/productivity/calendar/sychronization-with-google-s-calendar.html?highlight=google</attribute>
 	       </xpath>
 	    </field>

--- a/viin_brand_iap/views/res_config_settings.xml
+++ b/viin_brand_iap/views/res_config_settings.xml
@@ -10,7 +10,7 @@
             </xpath>
             <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/developer/webservices/iap.html']"
             position="attributes"> 
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/steps-to-create-viindoo-instance.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/system-settings/steps-to-create-viindoo-instance.html</attribute>
             </xpath>
         </field>
     </record>

--- a/viin_brand_mrp/views/res_config_settings_views.xml
+++ b/viin_brand_mrp/views/res_config_settings_views.xml
@@ -5,17 +5,16 @@
 	    <field name="inherit_id" ref="mrp.res_config_settings_view_form"/>
 	    <field name="arch" type="xml">
 	        <xpath expr="//div[@id='work_order']/div/a" position='attributes'>
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/manufacturing/operations/how-to-manage-work-orders-in-viindoo.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/manufacturing/products/how-to-manage-semi-finished-products-in-viindoo.html#configurations-for-semi-finished-products</attribute>
 	        </xpath>
-            <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/inventory_and_mrp/manufacturing/management/subcontracting.html']"
-            position='attributes'>
+            <xpath expr="//div[@name='process_operations_setting_container']/div/div/a" position='attributes'>
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/manufacturing/operations/manage-subcontracts-in-your-manufacturing-proccess.html</attribute>
             </xpath>
             <xpath expr="//div[@id='mrp_mps']/div/a" position='attributes'>
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/manufacturing/planning/how-to-use-the-master-production-schedule-in-viindoo.html</attribute>
             </xpath>
             <xpath expr="//div[@id='security_lead_time']/div/a" position='attributes'>
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/planning/understand-the-scheduled-delivery-date-computed-rule.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/planning/understanding-the-scheduled-delivery-date-computation.html</attribute>
             </xpath>
 	    </field>
 	</record>

--- a/viin_brand_payment_authorize/views/payment_views.xml
+++ b/viin_brand_payment_authorize/views/payment_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">payment.acquirer</field>
 	    <field name="inherit_id" ref="payment_authorize.acquirer_form_authorize"/>
 	    <field name="arch" type="xml">
-	        <xpath expr="//group[@name='acquirer']/group/a[@href='https://www.odoo.com/documentation/14.0/applications/general/payment_acquirers/authorize.html']" 
+	        <xpath expr="//group[@name='acquirer']/group/a" 
 	        position='attributes'>
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/finance/accounting-and-invoicing/account-receivables/customer-payments/how-to-make-a-payment-with-authorize-net.html</attribute>
 	        </xpath>

--- a/viin_brand_payment_paypal/views/payment_views.xml
+++ b/viin_brand_payment_paypal/views/payment_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">payment.acquirer</field>
 	    <field name="inherit_id" ref="payment_paypal.acquirer_form_paypal"/>
 	    <field name="arch" type="xml">
-	        <xpath expr="//group[@name='acquirer']/group/a[@href='https://www.odoo.com/documentation/14.0/applications/general/payment_acquirers/paypal.html']" 
+	        <xpath expr="//group[@name='acquirer']/group/a" 
 	        position='attributes'>
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/finance/accounting-and-invoicing/account-receivables/customer-payments/how-to-make-a-payment-with-paypal.html#pay-with-paypal</attribute>
 	        </xpath>

--- a/viin_brand_pos_mercury/views/pos_config_settings_views.xml
+++ b/viin_brand_pos_mercury/views/pos_config_settings_views.xml
@@ -4,7 +4,7 @@
 		<field name="model">res.config.settings</field>
 		<field name="inherit_id" ref="pos_mercury.res_config_settings_view_form_inherit_pos_mercury"/>
 		<field name="arch" type="xml">
-		    <xpath expr="//div/a[@href='https://www.odoo.com/page/point-of-sale-hardware#part_8']" position="attributes">
+		    <xpath expr="//div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/intro/pos</attribute>
 		    </xpath>
 		</field>

--- a/viin_brand_purchase/views/res_config_settings_views.xml
+++ b/viin_brand_purchase/views/res_config_settings_views.xml
@@ -8,10 +8,10 @@
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/purchase/manage-deals/purchase-agreement-blaket-orders.html</attribute>
             </xpath>
             <xpath expr="//div[@id='quantities_billed_vendor']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/purchase/manage-deals/alert-the-payment-deadline-in-vendor-bills.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/purchase/manage-deals/vendor-bills-control.html</attribute>
             </xpath>
             <xpath expr="//div[@id='three_way_matching']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/purchase/manage-deals/alert-the-payment-deadline-in-vendor-bills.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/purchase/manage-deals/vendor-bills-control.html</attribute>
             </xpath>
             <xpath expr="//div[@id='variant_options']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/getting-started/products/using-product-variants-in-viindoo.html</attribute>

--- a/viin_brand_purchase_stock/views/res_config_settings_views.xml
+++ b/viin_brand_purchase_stock/views/res_config_settings_views.xml
@@ -16,7 +16,7 @@
         <field name="inherit_id" ref="purchase_stock.res_config_settings_view_form_stock"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='schedule_receivings_setting_container']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/planning/understand-the-scheduled-delivery-date-computed-rule.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/planning/understanding-the-scheduled-delivery-date-computation.html</attribute>
             </xpath>
         </field>
     </record>

--- a/viin_brand_sale/views/res_config_settings_views.xml
+++ b/viin_brand_sale/views/res_config_settings_views.xml
@@ -23,7 +23,7 @@
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales/invoicing-method/issuing-invoices-based-on-order-quantity-or-delivery-quantity.html</attribute>
             </xpath>
             <xpath expr="//div[@id='down_payments']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales/invoicing-method/down-payment-in-viindoo-sales</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales/invoicing-method/down-payment-in-viindoo-sales.html</attribute>
             </xpath>
             <xpath expr="//div[@id='amazon_connector']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/sales/sales.html</attribute>

--- a/viin_brand_sale_stock/views/res_config_settings_views.xml
+++ b/viin_brand_sale_stock/views/res_config_settings_views.xml
@@ -4,8 +4,8 @@
 	    <field name="model">res.config.settings</field>
 	    <field name="inherit_id" ref="sale_stock.res_config_settings_view_form_stock"/>
 	    <field name="arch" type="xml">
-            <xpath expr="//a[@href='https://www.odoo.com/documentation/14.0/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html']" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/planning/understand-the-scheduled-delivery-date-computed-rule.html</attribute>
+            <xpath expr="//div[hasclass('o_setting_right_pane')]/a" position="attributes">
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/planning/understanding-the-scheduled-delivery-date-computation.html</attribute>
             </xpath>
         </field>
     </record>

--- a/viin_brand_stock/views/res_config_settings_views.xml
+++ b/viin_brand_stock/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/products/how-to-use-different-units-of-measure-packages-or-packaging.html</attribute>
             </xpath>
             <xpath expr="//div[@id='process_operations_barcodes']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/barcode.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/warehouse-management/products/how-to-use-different-units-of-measure-packages-or-packaging.html#product-packagings</attribute>
             </xpath>
             <xpath expr="//div[@id='compute_shipping_costs_ups']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory.html/</attribute>
@@ -49,10 +49,10 @@
                 </attribute>
             </xpath>
             <xpath expr="//div[@id='use_own_routes']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/advanced-routes/understand-pull-push-rules-in-supply-routes.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/advanced-routes/understanding-pull-push-rules-in-supply-routes.html</attribute>
             </xpath>
             <xpath expr="//div[@id='use_own_routes']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/advanced-routes/understand-pull-push-rules-in-supply-routes.html</attribute>
+                <attribute name="href">https://viindoo.com/documentation/14.0/applications/supply-chain/inventory/advanced-routes/understanding-pull-push-rules-in-supply-routes.html</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Fix link document 14.0:
- viin_brand_base_setup
- viin_brand_iap
- viin_brand_mrp
- viin_brand_purchase
- viin_brand_purchase_stock
- viin_brand_sale
- viin_brand_sale_stock
- viin_brand_stock

Change xpath:
- viin_brand_auth_oauth
- viin_brand_auth_totp
- viin_brand_base_setup
- viin_brand_common
- viin_brand_google_calendar
- viin_brand_mrp
- viin_brand_payment_authorize
- viin_brand_payment_paypal
- viin_brand_pos_mercury
- viin_brand_sale_stock

Link video: https://drive.google.com/file/d/1Vct7iUAm8ClL8qmbymqh6NVzdJ1zPDnC/view?usp=sharing