### PR TITLE
[15.0][FIX] viin_brand_common: remove style not compatible with theme.

### DIFF
--- a/viin_brand_common/static/src/legacy/scss/form_view_extra.scss
+++ b/viin_brand_common/static/src/legacy/scss/form_view_extra.scss
@@ -18,16 +18,6 @@
 			}
         }
     }
-    
-    .oe_form_field_html {
-        span {
-            &.o_field_translate {
-                &.btn-link {
-                    color: $white;
-                }
-            }
-        }
-    }
 
 	.o_form_statusbar {
 


### PR DESCRIPTION
Related Issues: https://docs.google.com/spreadsheets/d/1hStWuKtmfSyETRzl99VfWioeqPJuFjlW7jYdxN_022g/edit#gid=631435415&range=44:44

- In v14, the background color of toolbars in HTML field is black, so we
add this style (`color:white`) to make a translate button more friendly with user.

![Screenshot from 2022-07-15 09-44-02](https://user-images.githubusercontent.com/90305443/179138739-158d7629-79eb-407c-85eb-09384ba713e7.png)


- In v15, HTML field changed their background color to white which makes
this button disappear on UI.

This PR will remove this style to make translate button visible in UI.


![Screenshot from 2022-07-15 09-45-34](https://user-images.githubusercontent.com/90305443/179138936-5ebec8cd-6236-4514-aadb-0272032f8f15.png)