### PR TITLE
[FIX][15.0] viin_brand_common:fix to adapt with standard button color

### DIFF
--- a/viin_brand_common/static/src/legacy/scss/form_view_extra.scss
+++ b/viin_brand_common/static/src/legacy/scss/form_view_extra.scss
@@ -27,6 +27,9 @@
                 }
             }
         }
+        a {
+            color: $white;
+        }
     }
 
 	.o_form_statusbar {


### PR DESCRIPTION
Ticket: https://viindoo.com/web#id=7556&menu_id=777&action=1076&active_id=22&model=helpdesk.ticket&view_type=form
Odoo 15.0 có commit `https://github.com/odoo/odoo/commit/5d598e4269431222ae28ac2196ff6f1f45466734` này khiến cho việc hiển thị button trong ảnh dưới bị hiển thị màu không chuẩn
![Screenshot from 2022-07-19 12-00-16](https://user-images.githubusercontent.com/56789189/179668460-a6140106-6939-4cf8-b83c-a63410e2c102.png)
