### PR TITLE
[FIX][15.0] viin_brand_web_editor: only change `color` link when it inside button

### DIFF
--- a/viin_brand_web_editor/static/src/scss/web_editor.backend.scss
+++ b/viin_brand_web_editor/static/src/scss/web_editor.backend.scss
@@ -1,7 +1,7 @@
-.oe_form_field_html {
-	a {
-		// Ensure the link is visible enough in the editor.
-		$oe-link-color: o-color('o-cc3-link');
-		color: if($oe-link-color, $oe-link-color, $white);
-	}
+.oe_form_field_html.oe_memo{
+    .btn.btn-primary.flat{
+        // Ensure the link is visible enough in the editor.
+        $oe-link-color: o-color('o-cc3-link');
+        color: if($oe-link-color, $oe-link-color, $white);
+    }
 }


### PR DESCRIPTION
Ticket: https://viindoo.com/web#id=7918&menu_id=89&model=helpdesk.ticket&view_type=form
Currently, we've just changed the text color inside button in html
field. But it causes another problem when insert only Link in html
field.
So we need to specific the class in scss to override style's rule in
core Odoo.

This PR will fix this problem.

Before:


![Screenshot from 2022-07-23 10-11-25](https://user-images.githubusercontent.com/90305443/180588460-3c870093-aefe-4366-b034-1a7cea94b0d3.png)



After:

![Screenshot from 2022-07-23 10-10-14](https://user-images.githubusercontent.com/90305443/180588456-434d8a2e-9e84-4df2-9fed-e2e73285331e.png)


