### PR TITLE
[FIX][15.0] viin_brand_auth_oauth: note TODO for not correct documentation link

### DIFF
--- a/viin_brand_auth_oauth/views/res_config_settings_views.xml
+++ b/viin_brand_auth_oauth/views/res_config_settings_views.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- TODO: replace correct link when Documentation v15 finished -->
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.setting.view.form</field>
         <field name="model">res.config.settings</field>


### PR DESCRIPTION
Thêm `TODO` để fix lại đúng link sau khi Documentation v15 Viindoo hoàn thành