### PR TITLE
[I18N] [15.0] viin_brand_hr_expense:  Add missing translation file

### DIFF
--- a/viin_brand_hr_expense/i18n/vi_VN.po
+++ b/viin_brand_hr_expense/i18n/vi_VN.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-14 03:25+0000\n"
+"PO-Revision-Date: 2022-09-14 03:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_expense
+#: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_my_unsubmitted
+msgid ""
+"Snap pictures of your receipts and let <b>Viindoo</b><br> automatically "
+"create expenses for you."
+msgstr "Chụp ảnh hóa đơn và để <b>Viindoo</b><br> tự động tạo chi tiêu giúp bạn."
+
+#. module: hr_expense
+#: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_my_all
+msgid ""
+"Snap pictures of your receipts and let <span><b>Viindoo</b></span><br> "
+"automatically create expenses for you."
+msgstr "Chụp ảnh hóa đơn và để <span><b>Viindoo</b></span><br> tự động tạo chi tiêu giúp bạn."

--- a/viin_brand_hr_expense/i18n/viin_brand_hr_expense.pot
+++ b/viin_brand_hr_expense/i18n/viin_brand_hr_expense.pot
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-14 03:26+0000\n"
+"PO-Revision-Date: 2022-09-14 03:26+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_expense
+#: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_my_unsubmitted
+msgid ""
+"Snap pictures of your receipts and let <b>Viindoo</b><br> automatically "
+"create expenses for you."
+msgstr ""
+
+#. module: hr_expense
+#: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_my_all
+msgid ""
+"Snap pictures of your receipts and let <span><b>Viindoo</b></span><br> "
+"automatically create expenses for you."
+msgstr ""


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- [Ticket: #7668](https://viindoo.com/web#id=7668&cids=1&model=helpdesk.ticket&view_type=form)

Desired behavior after PR is merged:
- Desire `Odoo` label is translated to `Viindoo` on Popup introduces invoice snapshot feature.
- Video: 

https://user-images.githubusercontent.com/96491226/190302290-5ac2ed11-c799-4a23-a8ab-a7e116978ac3.mp4



-----
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit