### PR TITLE
[FIX][15.0] viin_brand_website_sale: link Viindoo Ecommerce working properly when install module website_sale

### DIFF
--- a/viin_brand_website_sale/__manifest__.py
+++ b/viin_brand_website_sale/__manifest__.py
@@ -39,7 +39,7 @@ Editions Supported
     'version': '0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['website_sale', 'viin_brand_website'],
+    'depends': ['website_sale'],
 
     # always loaded
     'data': [

--- a/viin_brand_website_sale/views/templates.xml
+++ b/viin_brand_website_sale/views/templates.xml
@@ -1,7 +1,7 @@
 <odoo>
     <data>
         <template id="brand_promotion"
-            inherit_id="viin_brand_website.brand_promotion">
+            inherit_id="website_sale.brand_promotion">
             <xpath
                 expr="//t[@t-call='web.brand_promotion_message']"
                 position="replace">


### PR DESCRIPTION
- Ticket: https://viindoo.com/web#id=8648&menu_id=777&action=1075&model=helpdesk.ticket&view_type=form
- Khi cài module `website_sale` và `viin_brand_website_sale` thì ở footer chưa dẫn đúng link về Viindoo Ecommerce

![download](https://user-images.githubusercontent.com/102200922/190960453-f0e64c6a-7496-4296-ac57-93f04a61cdd4.png)
- Nguyên nhân là do đang kế thừa sai `brand_promotion`, dẫn đến ghi đè module `viind_brand_website` thay vì phải ghi đè module `website_sale` 
Kết quả sau khi fix: [Screencast from 19-09-2022 10:25:19.webm](https://user-images.githubusercontent.com/102200922/190945109-4c993e21-f60a-4b26-84c3-3f67eedb2441.webm)