### PR TITLE
[FIX][15.0] viin_brand_mail: show @ error recipient when edit log note

### DIFF
--- a/viin_brand_mail/static/src/components/message/message.scss
+++ b/viin_brand_mail/static/src/components/message/message.scss
@@ -37,3 +37,20 @@
         overflow-x: inherit;
     }
 }
+
+// #TODO Remove this code if we don't get the same error in 16+ 
+// Fix error when tagging name ,
+// Error overflow in status tag when zooming the screen web
+// Details PR: https://github.com/Viindoo/branding/pull/210
+// ID ticket: 7301
+span.o_ComposerSuggestion_part2, text-truncate {
+	overflow: hidden;
+} 
+.o_PartnerImStatusIcon {
+	overflow: hidden;
+}
+// Fix: Error display of missing user name on dropdown-menu
+.dropup .dropdown-menu {
+    bottom: auto !important;
+    margin-top: 40px !important;
+}


### PR DESCRIPTION
**1. Link ticket:** 

https://viindoo.com/web?db=i2l3lurxd24s#id=7301&menu_id=777&cids=1&action=1074&active_id=6&model=helpdesk.ticket&view_type=form

**2. Hành vi hiện tại trước khi PR:**
   ( scale to xuất hiện lỗi )
-     1. Truy cập một task trên project/ticket ...
-     2. Nhấn vào Gửi tin và gửi 1 tin 
-     3. Chỉnh sửa msg đó và @ người
 
![aâaaScreenshot from 2022-10-03 08-56-33](https://user-images.githubusercontent.com/94814697/193549795-306b03be-fd4e-4e87-8f57-466da16dc830.png)

-     4.phát hiện ra 1 bug khác khi sửa lại 1 log note và tag tên , thanh dropdown-menu bị che mất tên một số user bên trên

> ![Screenshot from 2022-11-15 15-05-33](https://user-images.githubusercontent.com/94814697/202148906-9de40b0a-a430-4ab4-b397-efe8e825546a.png)
>  _thực tế sẽ có một số user bên trên ntn_ 
> ![Screenshot from 2022-11-15 15-06-38](https://user-images.githubusercontent.com/94814697/202149367-e7b2ee0c-183c-468d-9c01-baa619357a7f.png)


**3. Hành vi mong muốn sau khi PR được hợp nhất:**

      Có thể scale và tag tên mà không còn bị lỗi overflow , sửa log note đầu tiên không bị che tên một số user 
      **Video trước và sau khi fix bug thực hiên trên Chorm, Firefox !**

https://user-images.githubusercontent.com/94814697/202143532-6395ca40-e985-4cfa-a6b7-7c9565ee5205.mp4

      Video mobie rất ngắn nhưng vẫn mất hơn 10mb nên em không đăng trực tiếp được ! link tham khảo test trên mobie
https://drive.google.com/file/d/1fc-ujDD03xB4tYDYaiazPU8JY7D4croE/view



I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit