### PR TITLE
[UPG] [16.0] viin_brand_sale_stock: Upgrade module to 16.0

### DIFF
--- a/viin_brand_sale_stock/__manifest__.py
+++ b/viin_brand_sale_stock/__manifest__.py
@@ -53,9 +53,9 @@ Module này sẽ thay đổi giao diện các module Sale-Stock theo thương hi
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale_stock/views/res_config_settings_views.xml
+++ b/viin_brand_sale_stock/views/res_config_settings_views.xml
@@ -4,7 +4,7 @@
 	    <field name="model">res.config.settings</field>
 	    <field name="inherit_id" ref="sale_stock.res_config_settings_view_form_stock"/>
 	    <field name="arch" type="xml">
-            <xpath expr="//a[@href='https://www.odoo.com/documentation/15.0/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html']" position="attributes">
+            <xpath expr="//a[@href='https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html']" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/15.0/applications/supply-chain/inventory/warehouse-management/planning/understanding-the-scheduled-delivery-date-computation.html</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
Reference of the issue/task this PR addresses:

Current behavior before PR:

- Task: [31904](https://viindoo.com/web#id=31904&menu_id=289&action=409&active_id=216&model=project.task&view_type=form)

Desired behavior after PR is merged:

- Upgrade module to version 16.0

Video: 

https://user-images.githubusercontent.com/96491226/198842301-62ac7845-0d1d-42da-9b89-5fb8bc6ab527.mp4


