### PR TITLE
[UPG][16.0] viin_brand_sale_quotation_builder: upgrade to 16.0

### DIFF
--- a/viin_brand_sale_quotation_builder/__manifest__.py
+++ b/viin_brand_sale_quotation_builder/__manifest__.py
@@ -50,9 +50,9 @@ Editions Supported
     'images': [
     	# 'static/description/main_screenshot.png'
     	],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale_quotation_builder/i18n/vi_VN.po
+++ b/viin_brand_sale_quotation_builder/i18n/vi_VN.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-25 09:16+0000\n"
-"PO-Revision-Date: 2022-04-25 09:16+0000\n"
+"POT-Creation-Date: 2022-10-31 07:54+0000\n"
+"PO-Revision-Date: 2022-10-31 07:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/viin_brand_sale_quotation_builder/i18n/viin_brand_sale_quotation_builder.pot
+++ b/viin_brand_sale_quotation_builder/i18n/viin_brand_sale_quotation_builder.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-25 09:16+0000\n"
-"PO-Revision-Date: 2022-04-25 09:16+0000\n"
+"POT-Creation-Date: 2022-10-31 07:51+0000\n"
+"PO-Revision-Date: 2022-10-31 07:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
https://viindoo.com/web#id=31903&menu_id=289&action=409&active_id=216&model=project.task&view_type=form&cids=1
Current behavior before PR:

Desired behavior after PR is merged:

- Upgrade module to version 16.0


https://user-images.githubusercontent.com/91303385/198962187-f957428b-37bc-43fd-9b21-510879a050e3.mp4



