### PR TITLE
[UPG][16.0] viin_brand_web_editor: Upgrade module to 16.0

### DIFF
--- a/viin_brand_web_editor/__manifest__.py
+++ b/viin_brand_web_editor/__manifest__.py
@@ -43,7 +43,7 @@ Editions Supported
             ('after','web_editor/static/src/scss/web_editor.backend.scss','viin_brand_web_editor/static/src/scss/web_editor.backend.scss'),
         ],
     },
-    'installable': False,
+    'installable': True,
     'application': False,
     'auto_install': False, # set ['web_editor'] after upgrade 16.0
     'price': 9.9,

--- a/viin_brand_web_editor/static/src/scss/web_editor.backend.scss
+++ b/viin_brand_web_editor/static/src/scss/web_editor.backend.scss
@@ -1,4 +1,4 @@
-.oe_form_field_html{
+.o_field_html{
     a.btn{
         &.btn-primary,
         &.btn-fill-primary{


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
https://viindoo.com/web#id=31908&menu_id=89&model=project.task&view_type=form

Current behavior before PR:
*  depend: #277 

Desired behavior after PR is merged:

Upgrade module to version 16.0



https://user-images.githubusercontent.com/88885786/199375060-4758d273-0f81-40b4-a935-6a0a44f57d55.mp4


