### PR TITLE
[UPG][16.0] viin_brand_sale : UPG module to 16

### DIFF
--- a/viin_brand_sale/__manifest__.py
+++ b/viin_brand_sale/__manifest__.py
@@ -41,7 +41,7 @@ Module này sẽ thay đổi giao diện các module Sale theo thương hiệu V
     'support': "apps.support@viindoo.com",
 
     # Categories can be used to filter modules in modules listing
-    # Check https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
+    # Check https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Hidden',
     'version': '0.1',
@@ -54,9 +54,9 @@ Module này sẽ thay đổi giao diện các module Sale theo thương hiệu V
         'views/res_config_settings_views.xml',
         'views/sale_views.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True, 
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale/views/res_config_settings_views.xml
+++ b/viin_brand_sale/views/res_config_settings_views.xml
@@ -16,9 +16,6 @@
             <xpath expr="//div[@id='sale_config_online_confirmation_pay']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/15.0/applications/sales/sales/send-quotations/activate-online-payment-for-viindoo-website.html</attribute>
             </xpath>
-            <xpath expr="//div[@id='invoice_delivery_addresses']/div/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/15.0/applications/sales/sales/send-quotations/manage-invoicing-address-and-delivery-address-in-sales.html</attribute>
-            </xpath>
             <xpath expr="//div[@id='sales_settings_invoicing_policy']/div/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/15.0/applications/sales/sales/invoicing-method/issuing-invoices-based-on-order-quantity-or-delivery-quantity.html</attribute>
             </xpath>


### PR DESCRIPTION
https://viindoo.com/web#id=31901&menu_id=89&cids=1&model=project.task&view_type=form

Note:  ở phiên bản 16 của odoo thì id invoice_delivery_addresses đã chuyển từ module sale sang account

video:
[Screencast from 11-01-2022 08:30:34 AM.webm](https://user-images.githubusercontent.com/71915612/199139277-dc6ccab3-1e5d-422b-8890-d6eca9e4e983.webm)

![image](https://user-images.githubusercontent.com/71915612/199144245-8b5fdebc-1610-44d0-bcdb-abb5ccebddd6.png)


--
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit