### PR TITLE
[UPG][16.0] viin_brand_base_import: upgrade module to v16

### DIFF
--- a/viin_brand_base_import/__manifest__.py
+++ b/viin_brand_base_import/__manifest__.py
@@ -50,14 +50,13 @@ Module này sẽ thay đổi giao diện module Base import theo thương hiệu
     'depends': ['base_import'],
 
     # always loaded
-    'assets':{
-        'web.assets_qweb': [
+    'assets': {
+        'web.assets_backend':[
             'viin_brand_base_import/static/src/xml/base_import.xml',
-            ]
-    },
-    'installable': False,
+            ]},
+    'installable': True,
     'application': False,
-    'auto_install': False,  # set True after upgrade to 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',


### PR DESCRIPTION
https://viindoo.com/web#id=31871&menu_id=89&model=project.task&view_type=form

Thay đổi link hướng dẫn của odoo sang link hướng dẫn của viindoo trong phần Import
Change web.assets_qweb -> web.assets_backend in manifrest
video:
[Screencast from 01-11-2022 15:39:29.webm](https://user-images.githubusercontent.com/97087223/199193370-341d5fe4-b2f4-48fa-93de-4a748722fcde.webm)
