### PR TITLE
[UPG][16.0] viin_brand_fleet: upgrade to 16.0

### DIFF
--- a/viin_brand_fleet/__manifest__.py
+++ b/viin_brand_fleet/__manifest__.py
@@ -30,12 +30,12 @@ Module này sẽ thay đổi giao diện module Fleet theo thương hiệu Viind
 
     'author': "Viindoo",
     'website': "https://viindoo.com",
-    'live_test_url': "https://v15demo-int.viindoo.com",
-    'live_test_url_vi_VN': "https://v15demo-vn.viindoo.com",
+    'live_test_url': "https://v16demo-int.viindoo.com",
+    'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",
 
     # Categories can be used to filter modules in modules listing
-    # Check https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
+    # Check https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Hidden',
     'version': '0.1',
@@ -48,9 +48,9 @@ Module này sẽ thay đổi giao diện module Fleet theo thương hiệu Viind
         'views/fleet_board_view.xml',
         'views/fleet_vehicle_cost_views.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_fleet/i18n/vi_VN.po
+++ b/viin_brand_fleet/i18n/vi_VN.po
@@ -3,10 +3,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-23 08:46+0000\n"
-"PO-Revision-Date: 2022-09-23 08:46+0000\n"
+"POT-Creation-Date: 2022-11-01 08:03+0000\n"
+"PO-Revision-Date: 2022-11-01 08:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/viin_brand_fleet/i18n/viin_brand_fleet.pot
+++ b/viin_brand_fleet/i18n/viin_brand_fleet.pot
@@ -3,10 +3,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-23 08:45+0000\n"
-"PO-Revision-Date: 2022-09-23 08:45+0000\n"
+"POT-Creation-Date: 2022-11-01 08:03+0000\n"
+"PO-Revision-Date: 2022-11-01 08:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
https://viindoo.com/web#id=31877&menu_id=289&action=409&active_id=216&model=project.task&view_type=form&cids=1
Current behavior before PR:

Desired behavior after PR is merged:

1. Upgrade module to version 16.0


https://user-images.githubusercontent.com/91303385/199194047-4568b6a3-c9b9-43c1-afbf-905688679c03.mp4

