### PR TITLE
[UPG][16.0] viin_brand_payment_paypal: upg for module to 16.0

### DIFF
--- a/viin_brand_payment_paypal/__manifest__.py
+++ b/viin_brand_payment_paypal/__manifest__.py
@@ -53,9 +53,9 @@ Module này sẽ thay đổi giao diện các module Paypal Payment Acquirer the
     'data': [
         'views/payment_views.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_payment_paypal/views/payment_views.xml
+++ b/viin_brand_payment_paypal/views/payment_views.xml
@@ -1,10 +1,10 @@
 <odoo>
-	<record id="payment_acquirer_form" model="ir.ui.view">
-	    <field name="name">acquirer.form.paypal</field>
-	    <field name="model">payment.acquirer</field>
-	    <field name="inherit_id" ref="payment_paypal.payment_acquirer_form"/>
+	<record id="payment_provider_form" model="ir.ui.view">
+	    <field name="name">provider.form.paypal</field>
+	    <field name="model">payment.provider</field>
+	    <field name="inherit_id" ref="payment_paypal.payment_provider_form"/>
 	    <field name="arch" type="xml">
-	        <xpath expr="//group[@name='acquirer']/group/a" 
+	        <xpath expr="//group[@name='provider_credentials']/group/a" 
 	        position='attributes'>
                 <attribute name="href">https://viindoo.com/documentation/15.0/applications/finance/accounting-and-invoicing/account-receivables/customer-payments/how-to-make-a-payment-with-paypal.html#pay-with-paypal</attribute>
 	        </xpath>


### PR DESCRIPTION
Task: https://viindoo.com/web#id=31894&menu_id=89&model=project.task&view_type=form

Before upg: link  `How to configure your paypal account?`  sẽ dẫn đến website hướng dẫn của Odoo
Video:
[viin_brand_payment_paypal_16_upg_before.webm](https://user-images.githubusercontent.com/59944544/199401562-5c805b8e-df99-48f1-9e38-9b84bc28c1f8.webm)

After upg: link  `How to configure your paypal account?`  sẽ dẫn đến website hướng dẫn của Viindoo
Video: 
[viin_brand_payment_paypal_16_upg_after.webm](https://user-images.githubusercontent.com/59944544/199401584-5eac1882-f985-49ae-8ed3-dfe3a31f4db6.webm)

Cải tiến: 
models `payment.acquirer` đã thay đổi thành `payment.provider` nên kế thừa view bị sai -> sửa lại kế thừa view


