### PR TITLE
[16.0][UPG] viin_brand_website_links : Upgrade to 16.0

### DIFF
--- a/viin_brand_website_links/__manifest__.py
+++ b/viin_brand_website_links/__manifest__.py
@@ -53,9 +53,9 @@ Module này sẽ thay đổi giao diện module Link Tracker theo thương hiệ
     'data': [
         'views/website_links_template.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_links/i18n/vi_VN.po
+++ b/viin_brand_website_links/i18n/vi_VN.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-20 09:52+0000\n"
-"PO-Revision-Date: 2022-07-20 09:52+0000\n"
+"POT-Creation-Date: 2022-11-07 01:36+0000\n"
+"PO-Revision-Date: 2022-11-07 01:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/viin_brand_website_links/i18n/viin_brand_website_links.pot
+++ b/viin_brand_website_links/i18n/viin_brand_website_links.pot
@@ -2,12 +2,10 @@
 # This file contains the translation of the following modules:
 # 	* viin_brand_website_links
 #
-msgid ""
-msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-20 09:52+0000\n"
-"PO-Revision-Date: 2022-07-20 09:52+0000\n"
+"POT-Creation-Date: 2022-11-07 01:36+0000\n"
+"PO-Revision-Date: 2022-11-07 01:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
Reference of the issue/task this PR addresses:

https://viindoo.com/web#id=31915&menu_id=89&model=project.task&view_type=form

Current behavior before PR:

Desired behavior after PR is merged:

[Screencast from 11-07-2022 08:32:29 AM.webm](https://user-images.githubusercontent.com/101797346/200209722-061beff6-a485-4251-b909-e97dd3c4ea89.webm)


--
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit