### PR TITLE
[UPG][16.0] viin_brand_purchase_stock: update to v16

### DIFF
--- a/viin_brand_purchase_stock/__manifest__.py
+++ b/viin_brand_purchase_stock/__manifest__.py
@@ -53,9 +53,9 @@ Module này sẽ thay đổi giao diện các module Purchase Stock theo thươn
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
-    'auto_install': False, # set True after upgrade 16.0
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',


### PR DESCRIPTION
Reference of the issue/task this PR addresses:

Current behavior before PR: https://viindoo.com/web#id=31900&menu_id=89&model=project.task&view_type=form
video upg
[brandingpurchasestock.webm](https://user-images.githubusercontent.com/52828502/200453455-fa33edaf-3441-4f0a-92e7-516362f30dcd.webm)




I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit