### PR TITLE
[FIX][15.0] viin_brand_account: Change xpath to avoid errors

### DIFF
--- a/viin_brand_account/views/account_move_views.xml
+++ b/viin_brand_account/views/account_move_views.xml
@@ -5,10 +5,10 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_activate_currency'][text()[contains(., 'bill')]]" position="replace">
+            <xpath expr="//button[@name='action_activate_currency']" position="replace">
                 <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the bill</button>. The journal entries need to be computed by the system before being posted in your company's currency.
             </xpath>
-            <xpath expr="//button[@name='action_activate_currency'][text()[contains(., 'invoice')]]" position="replace">
+            <xpath expr="//button[@name='action_activate_currency'][last()]" position="replace">
                 <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the invoice</button>. The journal entries need to be computed by the system before being posted in your company's currency.
             </xpath>
         </field>

--- a/viin_brand_base_import/static/src/xml/base_import.xml
+++ b/viin_brand_base_import/static/src/xml/base_import.xml
@@ -13,14 +13,14 @@
     
     <t t-name="ImportView.preview" t-inherit="base_import.ImportView.preview"
     t-inherit-mode="extension">   
-       	<xpath expr="//tr/td/span[text()[contains(., 'Odoo')]]" position="replace">
+       	<xpath expr="//tr/td[@style='width: 15%;']/span" position="replace">
        		<span class="o_single_line_text" title="File Column">System Field</span>
        	</xpath>
     </t>
 
     <t t-name="ImportView.data_matching" t-inherit="base_import.ImportView.data_matching"
     t-inherit-mode="extension">
-    	<xpath expr="//p[text()[contains(., 'Odoo')]]" position="replace">
+    	<xpath expr="//div/div/p" position="replace">
     		<p class="alert alert-info">If the file contains
                 the column names, the system can try auto-detecting the
                 field corresponding to the column. This makes imports

--- a/viin_brand_website_links/views/website_links_template.xml
+++ b/viin_brand_website_links/views/website_links_template.xml
@@ -3,7 +3,7 @@
         <xpath expr="//form[@id='o_website_links_link_tracker_form']/div/div/input[@id='url']" position="attributes">
             <attribute name="placeholder">e.g. https://viindoo.com</attribute>
         </xpath>
-        <xpath expr="//div[hasclass('o_website_links_create_tracked_url')]/div/div[hasclass('row')]/div/p[text()[contains(., 'Odoo')]]" position="replace">
+        <xpath expr="//div[hasclass('o_website_links_create_tracked_url')]/div/div[hasclass('row')]/div/p[last()]" position="replace">
             <p class="text-muted text-justify">Those trackers can be used in Google Analytics to track clicks and visitors, or in Viindoo reports to track opportunities and related revenues.</p>
         </xpath>
     </template>


### PR DESCRIPTION
After this pr https://github.com/Viindoo/branding/pull/254, expression of xpath using text() contains. With this way, errors will raise if language user is not English.
This PR will fix this problem

- [x] viin_brand_account

Preview in VN:

![Screenshot from 2022-11-11 09-48-18](https://user-images.githubusercontent.com/90305443/201252372-6cba4ee9-4607-4221-8aae-082f2ca3ce56.png)

- [x] viin_brand_base_import

Preview in VN:

![image](https://user-images.githubusercontent.com/90305443/201258965-6cdfb876-38d1-44a0-b5c1-dccc5d3b10c9.png)


- [x] viin_brand_website_links

Preview in VN:

![Screenshot from 2022-11-11 11-01-24](https://user-images.githubusercontent.com/90305443/201260681-401daf94-f8b5-4eec-8a69-dc8137297872.png)
