### PR TITLE
[IMP][15.0] viin_brand_account: Change xpath to button activate the currency

### DIFF
--- a/viin_brand_account/views/account_move_views.xml
+++ b/viin_brand_account/views/account_move_views.xml
@@ -5,10 +5,10 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_activate_currency']" position="replace">
+            <xpath expr="//div[@attrs=&quot;{'invisible': ['|', ('display_inactive_currency_warning', '=', False), ('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}&quot;]/button" position="replace">
                 <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the bill</button>. The journal entries need to be computed by the system before being posted in your company's currency.
             </xpath>
-            <xpath expr="//button[@name='action_activate_currency'][last()]" position="replace">
+            <xpath expr="//div[@attrs=&quot;{'invisible': ['|', ('display_inactive_currency_warning', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund', 'out_receipt'))]}&quot;]/button" position="replace">
                 <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the invoice</button>. The journal entries need to be computed by the system before being posted in your company's currency.
             </xpath>
         </field>


### PR DESCRIPTION
Hiện tại:
Button hiện ở hóa đơn khách hàng không nhận xpath
Video:
[viin_brand_account_before.webm](https://user-images.githubusercontent.com/59944544/203233552-52c7b369-e6cd-45f3-aa78-641f26c6941c.webm)


Sau khi sửa:
Button hiện ở hóa đơn khách hàng và hóa đơn nhà cung cấp đều nhận xpath
Video: 
[viin_brand_account_after.webm](https://user-images.githubusercontent.com/59944544/203233567-def3e3c5-e0bd-4599-9382-e19e08088095.webm)

