### PR TITLE
[FIX][15.0] viin_brand_web: fix for loop when loop `GRAPH_COLORS`

### DIFF
--- a/viin_brand_web/static/src/js/colors.js
+++ b/viin_brand_web/static/src/js/colors.js
@@ -7,6 +7,6 @@ var GRAPH_COLORS = ["#00bbce", "#7f4282", "#dd3baf", "#00B365", "#0099E6",
     "#66f0ff", "#c796ca", "#ee9dd6", "#59ffb6", "#73d0ff",
     "#ffe598", "#e5a8a8", "#ffd07f", "#ca95ca", "929ca6"];
 
-for (let i=0;i<=GRAPH_COLORS.length;i++){
+for (let i=0;i<GRAPH_COLORS.length;i++){
     COLORS[i] = GRAPH_COLORS[i]
 }


### PR DESCRIPTION
**PR này để:**
- Sửa lỗi khi lặp qua mảng màu `GRAPH_COLOR`
- Index chạy từ 0 tới 19 ( 20 index) thay vì chạy từ 0 tới 20 ( 21 index )