### PR TITLE
[IMP][16.0] viin_brand_mail: Change color status icon

### DIFF
--- a/viin_brand_mail/static/src/components/partner_im_status_icon/partner_im_status_icon.scss
+++ b/viin_brand_mail/static/src/components/partner_im_status_icon/partner_im_status_icon.scss
@@ -11,3 +11,7 @@
         color: $brand-primary; 
     }
 }
+
+.text-primary {
+	color: $brand-primary !important;
+}


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
https://viindoo.com/web#id=45753&cids=1&menu_id=89&model=helpdesk.ticket&view_type=form

Description:
Change color status icon in Status partner messages

Before fixing:
![download](https://user-images.githubusercontent.com/107665841/230843080-9a91498d-8136-4bff-87b5-e111ea6ae830.png)

After fixing:
![image](https://user-images.githubusercontent.com/107665841/230826353-9c664f02-77e9-4e69-b5cf-24f31737b0f8.png)

--
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit