### PR TITLE
[IMP][16.0] viin_brand_mail: Hide mass mailing form

### DIFF
--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -37,7 +37,7 @@ Editions Supported
     'version': '0.1.0',
 
     # any module necessary for this one to work correctly
-    'depends': ['mail', 'viin_brand_common'],
+    'depends': ['viin_brand_common', 'mass_mailing_themes'],
 
     # always loaded
     'data': [

--- a/viin_brand_mail/views/mail_data.xml
+++ b/viin_brand_mail/views/mail_data.xml
@@ -10,4 +10,8 @@
 			<a target="_blank" href="https://viindoo.com?utm_source=db&amp;utm_medium=email" style="color: #66C8D3;">Viindoo</a>
 		</xpath>
 	</template>
+	
+	<template id="email_designer_snippets" inherit_id="mass_mailing_themes.email_designer_snippets">
+		<xpath expr="//div[@data-name='newsletter']" position="replace" priority="999" />
+	</template>
 </odoo>


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
https://viindoo.com/web#id=45756&cids=1&menu_id=89&model=helpdesk.ticket&view_type=form

Description:
Hide the new Odoo-branded email template

Before fixing:

![Screenshot from 2023-04-26 09-59-32](https://user-images.githubusercontent.com/107665841/234455954-2207f437-3cd4-4de7-9c0f-73ffe39f5748.png)

After fixing:

![image](https://user-images.githubusercontent.com/107665841/234454934-cf77ab04-a19f-41d3-ab0b-9bf1c807379d.png)

--
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit