### PR TITLE
[IMP][15.0] viin_brand_auth_oauth: hide  Log in with Odoo.com

### DIFF
--- a/viin_brand_auth_oauth/__manifest__.py
+++ b/viin_brand_auth_oauth/__manifest__.py
@@ -52,6 +52,7 @@ Module này sẽ thay đổi giao diện module OAuth2 Authentication theo thư�
     # always loaded
     'data': [
         'views/res_config_settings_views.xml',
+        'data/auth_oauth_data.xml',
     ],
     'installable': True,
     'application': False,

--- a/viin_brand_auth_oauth/data/auth_oauth_data.xml
+++ b/viin_brand_auth_oauth/data/auth_oauth_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+    	<function name="write" model="auth.oauth.provider">
+	        <value eval="[ref('auth_oauth.provider_openerp')]" />
+	        <value eval="{'enabled': False}" />
+    	</function>
+    </data>
+</odoo>


### PR DESCRIPTION
Current behavior before PR:
![Screenshot 2023-06-07 at 13 46 35](https://github.com/Viindoo/branding/assets/41675989/fb03f94f-63d3-4a2c-b272-88b15240e7e6)


Desired behavior after PR is merged:
![Screenshot 2023-06-07 at 13 48 20](https://github.com/Viindoo/branding/assets/41675989/da063e2b-3ac2-44a9-b92c-3de07e3f8d58)

![Screenshot 2023-06-07 at 13 47 26](https://github.com/Viindoo/branding/assets/41675989/b63b54f3-1cca-4e5a-a133-c1e795e79e9c)

---
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit