### PR TITLE
[IMP][15.0] viin_brand_base_setup: replace odoo by viindoo

### DIFF
--- a/viin_brand_base_setup/__manifest__.py
+++ b/viin_brand_base_setup/__manifest__.py
@@ -53,6 +53,11 @@ Module này sẽ thay đổi giao diện module Initial Setup Tools theo thươn
     'data': [
         'views/res_config_settings_views.xml',
     ],
+    'assets': {
+        'web.assets_qweb': [
+            'viin_brand_base_setup/static/src/xml/res_config_edition.xml',
+        ],
+    },
     'installable': True,
     'application': False,
     'auto_install': True,

--- a/viin_brand_base_setup/static/src/xml/res_config_edition.xml
+++ b/viin_brand_base_setup/static/src/xml/res_config_edition.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template>
+    <t t-inherit="base_setup.res_config_edition" t-inherit-mode="extension">
+        <xpath expr="//h3" position="replace">
+            <h3> Viindoo <t t-esc="widget.server_version" /> (Community Edition) </h3>
+        </xpath>
+        <xpath expr="//a[@href='https://www.odoo.com']" position="replace">
+            <a target="_blank" href="https://www.viindoo.com" style="text-decoration: underline;">
+                Viindoo</a>
+        </xpath>
+    </t>
+</template>


### PR DESCRIPTION
Current behavior before PR:
![Screenshot 2023-06-09 at 14 02 05](https://github.com/Viindoo/branding/assets/41675989/0207f3af-955e-4747-8e5a-35d5b0f200e3)
Desired behavior after PR is merged:
![Screenshot 2023-06-09 at 14 04 57](https://github.com/Viindoo/branding/assets/41675989/ec053cc1-6165-469a-b0a0-cab22e106c68)


---
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit