### PR TITLE
[FIX][16.0] viin_brand_pos:  update new path for  file primary_variables.scss

### DIFF
--- a/viin_brand_pos/__manifest__.py
+++ b/viin_brand_pos/__manifest__.py
@@ -56,7 +56,7 @@ Module này sẽ thay đổi màu sắc của thanh điều hướng (navbar), c
     ],
     'assets': {
         'point_of_sale.assets': [
-            ('prepend', 'viin_brand_common/static/src/legacy/scss/primary_variables.scss'),
+            ('prepend', 'viin_brand_common/static/src/scss/primary_variables.scss'),
             ('prepend', 'viin_brand_common/static/src/legacy/scss/bootstrap_overridden_common.scss'),
             ('after', 'point_of_sale/static/src/scss/pos.scss', 'viin_brand_pos/static/src/scss/style.scss'),
             'viin_brand_pos/static/src/xml/Chrome.xml',


### PR DESCRIPTION
PR này để xử lý ticket: [[BUG] Branding: Error when access to POS](https://viindoo.com/web#id=48044&cids=1&menu_id=89&model=helpdesk.ticket&view_type=form)
- Nguyên nhân: do đường dẫn file scss đã thay đổi
- Hình ảnh sau khi xử lý
<img width="1435" alt="Screenshot 2023-06-30 at 1 43 41 PM" src="https://github.com/Viindoo/branding/assets/41675989/cb650444-6cb4-46d3-9218-f6f3e77d0ea8">



---
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit