### PR TITLE
[IMP][16.0] viin_brand_base_setup: Hide function not available yet

### DIFF
--- a/viin_brand_base_setup/views/res_config_settings_views.xml
+++ b/viin_brand_base_setup/views/res_config_settings_views.xml
@@ -20,6 +20,9 @@
             <xpath expr="//div[./label[@for='module_web_unsplash']]/a" position="attributes">
                 <attribute name="href">https://viindoo.com/documentation/15.0/applications/websites/website/optimize/how-to-intergrate-with-free-image-library-at-unsplash.html</attribute>
             </xpath>
+            <xpath expr="//div[@id='sms']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
**Task:**[ [GH] Cải tiến repo branding phục vụ White Label Partner](https://viindoo.com/web#id=62461&cids=1&menu_id=89&model=project.task&view_type=form)


**Mô tả:** Ẩn config SMS do viindoo chưa có chức năng này
- Trước PR:
<img width="1115" alt="Screenshot 2023-07-12 at 5 17 32 PM" src="https://github.com/Viindoo/branding/assets/41675989/a4876799-03d9-4761-8582-67827daf0ac4">


- Sau PR: 

<img width="1154" alt="Screenshot 2023-07-12 at 5 16 37 PM" src="https://github.com/Viindoo/branding/assets/41675989/57b314f7-feb5-4941-871c-50d36461f1f3">



---
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit