### PR TITLE
[FIX][16] web_responsive:chatter permission when having _mail_post_access read

### DIFF
--- a/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -113,7 +113,7 @@
                                 'o-active btn-odoo': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
                                 'btn-light': chatterTopbar.chatter.composerView and !chatterTopbar.chatter.composerView.composer.isLog or !chatterTopbar.chatter.composerView,
                             }"
-                            t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                            t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                             t-on-click="chatterTopbar.chatter.onClickLogNote"
                             data-hotkey="shift+m"
                         >
@@ -130,7 +130,7 @@
                             <button
                                 class="o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity btn btn-light text-nowrap"
                                 type="button"
-                                t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                                t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                                 t-on-click="chatterTopbar.chatter.onClickScheduleActivity"
                                 data-hotkey="shift+a"
                             >


### PR DESCRIPTION
Chúng ta đang mong muốn là khi model có `_mail_post_access là read` thì người dùng có thể `send message, log note` giống như ở v15, nhưng ở v16 Odoo đang chỉ có `Send message` thồi

Đây là cuộc thảo luận rằng odoo đang cân nhắc `https://github.com/odoo/odoo/commit/d2b8612cf7d9c118a12a1f0407bbc893f07e4b56#r127836545`

Đây là PR e làm cho odoo `https://github.com/odoo/odoo/pull/135589`

=> Kiểu j kiểu mình cũng cần xử ở module này do nó replace lại cái khối chatter để responsive hơn