### PR TITLE
[IMP] [16.0] viin_brand_common: imp opacity sample data

### DIFF
--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -76,6 +76,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
             ('after', 'web/static/src/views/fields/progress_bar/progress_bar_field.scss', 'viin_brand_common/static/src/legacy/scss/progress_bar.scss'),
             ('after', 'web/static/src/views/form/button_box/button_box.scss', 'viin_brand_common/static/src/views/form/button_box/button_box.scss'),
             ('after', 'web/static/src/webclient/webclient.js', 'viin_brand_common/static/src/webclient/webclient.js'),
+            ('after', 'web/static/src/legacy/scss/utils.scss', 'viin_brand_common/static/src/legacy/scss/utils.scss'),
         ],
     },
     'installable': True,

--- a/viin_brand_common/static/src/legacy/scss/utils.scss
+++ b/viin_brand_common/static/src/legacy/scss/utils.scss
@@ -1,0 +1,3 @@
+@mixin o-sample-data-disabled {
+    opacity: 1.0;
+}


### PR DESCRIPTION
- Sample data đang hơi mờ, nhiều view không nhìn rõ nên em làm pr tăng opacity cho nó
- trước
![image](https://github.com/Viindoo/branding/assets/71593331/b6027964-d3c1-479a-adde-c4b548b19371)

- sau:

![image](https://github.com/Viindoo/branding/assets/71593331/65c93fdb-0ea8-4f7f-a394-fd0d61318b3f)
