### PR TITLE
[IMP][16.0] viin_brand_common: support apps update debranding through viindoo

### DIFF
--- a/viin_brand_common/__init__.py
+++ b/viin_brand_common/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -77,6 +77,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
             ('after', 'web/static/src/views/form/button_box/button_box.scss', 'viin_brand_common/static/src/views/form/button_box/button_box.scss'),
             ('after', 'web/static/src/webclient/webclient.js', 'viin_brand_common/static/src/webclient/webclient.js'),
             ('after', 'web/static/src/legacy/scss/utils.scss', 'viin_brand_common/static/src/legacy/scss/utils.scss'),
+            ('after', 'web/static/src/legacy/js/apps.js', 'viin_brand_common/static/src/legacy/js/apps.js'),
         ],
     },
     'installable': True,

--- a/viin_brand_common/models/__init__.py
+++ b/viin_brand_common/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_module

--- a/viin_brand_common/models/ir_module.py
+++ b/viin_brand_common/models/ir_module.py
@@ -1,0 +1,15 @@
+from odoo import models, api, tools
+
+
+class Module(models.Model):
+    _inherit = "ir.module.module"
+
+    @api.model
+    def get_apps_server(self):
+        """
+        Completely overide to change the apps_server
+        as well as return the modules of the client instance
+        """
+        # TODO: in v17 or master+ find a way to avoid changing return type of this method
+        modules = self.search_read([], ['name', 'installed_version'])
+        return tools.config.get('apps_server', 'https://viindoo.com/apps'), modules

--- a/viin_brand_common/static/src/legacy/js/apps.js
+++ b/viin_brand_common/static/src/legacy/js/apps.js
@@ -1,0 +1,117 @@
+/** @odoo-module **/
+
+import apps from 'web.Apps';
+import session from "web.session";
+import framework from 'web.framework';
+import {_t} from 'web.core';
+import {patch} from "web.utils";
+import config from "web.config";
+
+var apps_client = null;
+
+patch(apps.prototype, "viin_brand_common.apps", {
+	/**
+	 * @override
+	 * Completely overide to add 'modules' in the client object
+	 */
+	get_client: function() {
+		// return the client via a promise, resolved or rejected depending if
+		// the remote host is available or not.
+		var check_client_available = function(client) {
+			var i = new Image();
+			var def = new Promise(function (resolve, reject) {
+				i.onerror = function() {
+					reject(client);
+				};
+				i.onload = function() {
+					resolve(client);
+				};
+			});
+			i.src = _.str.sprintf('%s/to_base/static/description/main_screenshot.png', client.origin);
+			return def;
+		};
+		if (apps_client) {
+			return check_client_available(apps_client);
+		} else {
+			return this._rpc({model: 'ir.module.module', method: 'get_apps_server'})
+				.then(function(u) {
+					var link = $(_.str.sprintf('<a href="%s"></a>', u[0]))[0];
+					var host = _.str.sprintf('%s//%s', link.protocol, link.host);
+					var dbname = link.pathname;
+					if (dbname[0] === '/') {
+						dbname = dbname.substr(1);
+					}
+					var client = {
+						origin: host,
+						dbname: dbname
+					};
+					client.modules = u[1];
+					apps_client = client;
+					return check_client_available(client);
+			});
+		}
+	},
+	/**
+	 * @override
+	 * Completely overide to change the message noti and callback url
+	 */
+	start: function() {
+		var self = this;
+		return new Promise(function (resolve, reject) {
+			self.get_client().then(function (client) {
+				self.client = client;
+
+				var qs = {};
+				var u;
+				if (self.remote_action_tag === 'loempia.embed.updates') {
+					qs.modules = [client.modules];
+					u = $.param.querystring(client.origin + "/apps/embed/client/update", qs);
+				}else{
+					qs.db = client.dbname;
+					if (config.isDebug()) {
+						qs.debug = odoo.debug;
+					}
+					u = $.param.querystring(client.origin + "/apps/embed/client", qs);
+				}
+				var css = {width: '100%', height: '750px'};
+				self.$ifr = $('<iframe>').attr('src', u);
+
+				self.uniq = _.uniqueId('apps');
+				$(window).on("message." + self.uniq, self.proxy('_on_message'));
+
+				self.on('message:ready', self, function(m) {
+					var w = this.$ifr[0].contentWindow;
+					var act = {
+						type: 'ir.actions.client',
+						tag: this.remote_action_tag,
+						params: _.extend({}, this.params, {
+							db: session.db,
+							origin: session.origin,
+						})
+					};
+					w.postMessage({type:'action', action: act}, client.origin);
+				});
+
+				self.on('message:set_height', self, function(m) {
+					this.$ifr.height(m.height);
+				});
+
+				self.on('message:blockUI', self, function() { framework.blockUI(); });
+				self.on('message:unblockUI', self, function() { framework.unblockUI(); });
+				self.on('message:warn', self, function(m) {self.displayNotification({ title: m.title, message: m.message, sticky: m.sticky, type: 'danger' }); });
+
+				self.$ifr.appendTo(self.$('.o_content')).css(css).addClass('apps-client');
+
+				resolve();
+			}, function() {
+				self.displayNotification({ title: _t('Viindoo Marketplace will be available soon'), message: _t('Showing locally available modules'), sticky: true, type: 'danger' });
+				return self._rpc({
+					route: '/web/action/load',
+					params: {action_id: self.failback_action_id},
+				}).then(function(action) {
+					return self.do_action(action, {clear_breadcrumbs: true});
+				}).then(resolve, reject);
+			});
+		});
+	}
+});


### PR DESCRIPTION
related: https://github.com/Viindoo/tvtmaaddons/pull/9385

Kịch bản test
1. chạy 2 instance 16.0, 1 instance sẽ cài to_website_apps_store và lấy apps của viindoo cụ thể lấy ở bên ERP enterprise và odoo
2. ở instance còn lại ta thử downgrade version của app cụ thể là to_account_asset và 	l10n_vn_viin_account_asset xuống 1 phiên bản để kiểm thử
3. Kỳ vọng khi bấm vào apps update hệ thống instance số 2 sẽ check được 2 apps đó bị thấp phiên bản và thông tin cho người dùng
4. Ngoài ra khi bấm vào apps store sẽ render trang apps store của Viindoo luôn (có thể sẽ cải tiến show ra 1 trang web nào đó và trên trang đó mới có nút điều hướng đến apps store	)
Video: 

https://github.com/Viindoo/tvtmaaddons/assets/56789189/e8d11037-55e6-46ba-87a8-2668625abdce