### PR TITLE
[IMP] web_chatter_position: remove "sided" option, then move "auto" => "sided"

### DIFF
--- a/web_chatter_position/README.rst
+++ b/web_chatter_position/README.rst
@@ -38,7 +38,7 @@ Usage
 =====
 
 #. There's a **Chatter Position** option in **User Preferences**, where you can
-choose between ``auto``, ``bottom`` and ``sided``.
+choose between ``sided`` and ``bottom``.
 
 Bug Tracker
 ===========

--- a/web_chatter_position/i18n/fr.po
+++ b/web_chatter_position/i18n/fr.po
@@ -27,11 +27,6 @@ msgid "Chatter Position"
 msgstr "Position du Chatter"
 
 #. module: web_chatter_position
-#: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__auto
-msgid "Responsive"
-msgstr "Automatique"
-
-#. module: web_chatter_position
 #: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__sided
 msgid "Sided"
 msgstr "A droite"

--- a/web_chatter_position/i18n/hr.po
+++ b/web_chatter_position/i18n/hr.po
@@ -28,11 +28,6 @@ msgid "Chatter Position"
 msgstr "Pozicija razgovora"
 
 #. module: web_chatter_position
-#: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__auto
-msgid "Responsive"
-msgstr "Responzivno"
-
-#. module: web_chatter_position
 #: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__sided
 msgid "Sided"
 msgstr "Sa strane"

--- a/web_chatter_position/i18n/tr.po
+++ b/web_chatter_position/i18n/tr.po
@@ -27,11 +27,6 @@ msgid "Chatter Position"
 msgstr "Sohbet Pozisyonu"
 
 #. module: web_chatter_position
-#: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__auto
-msgid "Responsive"
-msgstr "Esnek"
-
-#. module: web_chatter_position
 #: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__sided
 msgid "Sided"
 msgstr ""

--- a/web_chatter_position/i18n/vi_VN.po
+++ b/web_chatter_position/i18n/vi_VN.po
@@ -26,11 +26,6 @@ msgid "Chatter Position"
 msgstr "Vị trí Chatter"
 
 #. module: web_chatter_position
-#: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__auto
-msgid "Responsive"
-msgstr "Tự động"
-
-#. module: web_chatter_position
 #: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__sided
 msgid "Sided"
 msgstr "Bên cạnh"

--- a/web_chatter_position/i18n/web_chatter_position.pot
+++ b/web_chatter_position/i18n/web_chatter_position.pot
@@ -26,11 +26,6 @@ msgid "Chatter Position"
 msgstr ""
 
 #. module: web_chatter_position
-#: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__auto
-msgid "Responsive"
-msgstr ""
-
-#. module: web_chatter_position
 #: model:ir.model.fields.selection,name:web_chatter_position.selection__res_users__chatter_position__sided
 msgid "Sided"
 msgstr ""

--- a/web_chatter_position/models/res_users.py
+++ b/web_chatter_position/models/res_users.py
@@ -9,11 +9,10 @@ class ResUsers(models.Model):
 
     chatter_position = fields.Selection(
         [
-            ("auto", "Responsive"),
-            ("bottom", "Bottom"),
             ("sided", "Sided"),
+            ("bottom", "Bottom"),
         ],
-        default="auto",
+        default="sided",
     )
 
     @property

--- a/web_chatter_position/readme/USAGE.rst
+++ b/web_chatter_position/readme/USAGE.rst
@@ -1,2 +1,2 @@
 #. There's a **Chatter Position** option in **User Preferences**, where you can
-choose between ``auto``, ``bottom`` and ``sided``.
+choose between ``sided`` and ``bottom``.

--- a/web_chatter_position/static/description/index.html
+++ b/web_chatter_position/static/description/index.html
@@ -386,7 +386,7 @@ ul.auto-toc {
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id1">Usage</a></h1>
 <p>#. There’s a <strong>Chatter Position</strong> option in <strong>User Preferences</strong>, where you can
-choose between <tt class="docutils literal">auto</tt>, <tt class="docutils literal">bottom</tt> and <tt class="docutils literal">sided</tt>.</p>
+choose between <tt class="docutils literal">sided</tt> and <tt class="docutils literal">bottom</tt>.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>

--- a/web_chatter_position/static/src/js/web_chatter_position.esm.js
+++ b/web_chatter_position/static/src/js/web_chatter_position.esm.js
@@ -5,7 +5,6 @@
 */
 
 import {FormCompiler} from "@web/views/form/form_compiler";
-import {FormController} from "@web/views/form/form_controller";
 import {MailFormCompiler} from "@mail/views/form/form_compiler";
 import {append} from "@web/core/utils/xml";
 import {patch} from "@web/core/utils/patch";
@@ -62,11 +61,9 @@ patch(MailFormCompiler.prototype, "web_chatter_position", {
         if (!chatterContainerHookXml) {
             return res;
         }
-        // Don't patch anything if the setting is "auto": this is the core behaviour
-        if (odoo.web_chatter_position === "auto") {
+        // Don't patch anything if the setting is "sided": this is the core behaviour
+        if (odoo.web_chatter_position === "sided") {
             return res;
-        } else if (odoo.web_chatter_position === "sided") {
-            chatterContainerHookXml.setAttribute("t-if", "!hasAttachmentViewer()");
         } else if (odoo.web_chatter_position === "bottom") {
             chatterContainerHookXml.setAttribute("t-if", false);
         }
@@ -75,21 +72,6 @@ patch(MailFormCompiler.prototype, "web_chatter_position", {
 });
 
 patch(FormCompiler.prototype, "web_chatter_position", {
-    /**
-     * Patch the css classes of the `Form`, to include an extra `h-100` class.
-     * Without it, the form sheet will not be full height in some situations,
-     * looking a bit weird.
-     *
-     * @override
-     */
-    compileForm() {
-        const res = this._super.apply(this, arguments);
-        if (odoo.web_chatter_position === "sided") {
-            const classes = res.getAttribute("t-attf-class");
-            res.setAttribute("t-attf-class", `${classes} h-100`);
-        }
-        return res;
-    },
     /**
      * Patch the visibility of bottom chatters (`A` and `B` above).
      * `B` may not exist in some situations, so we ensure it does by creating it.
@@ -107,20 +89,12 @@ patch(FormCompiler.prototype, "web_chatter_position", {
         if (chatterContainerHookXml.parentNode.classList.contains("o_form_sheet")) {
             return res;
         }
-        // Don't patch anything if the setting is "auto": this is the core behaviour
-        if (odoo.web_chatter_position === "auto") {
+        // Don't patch anything if the setting is "sided": this is the core behaviour
+        if (odoo.web_chatter_position === "sided") {
             return res;
-            // For "sided", we have to remote the bottom chatter
-            // (except if there is an attachment viewer, as we have to force bottom)
-        } else if (odoo.web_chatter_position === "sided") {
-            const formSheetBgXml = res.querySelector(".o_form_sheet_bg");
-            if (!formSheetBgXml) {
-                return res
-            }
-            chatterContainerHookXml.setAttribute("t-if", false);
-            // For "bottom", we keep the chatter in the form sheet
-            // (the one used for the attachment viewer case)
-            // If it's not there, we create it.
+        // For "bottom", we keep the chatter in the form sheet
+        // (the one used for the attachment viewer case)
+        // If it's not there, we create it.
         } else if (odoo.web_chatter_position === "bottom") {
             if (params.hasAttachmentViewerInArch) {
                 const sheetBgChatterContainerHookXml = res.querySelector(
@@ -145,21 +119,5 @@ patch(FormCompiler.prototype, "web_chatter_position", {
             }
         }
         return res;
-    },
-});
-
-patch(FormController.prototype, "web_chatter_position", {
-    /**
-     * Patch the css classes of the form container, to include an extra `flex-row` class.
-     * Without it, it'd go for flex columns direction and it won't look good.
-     *
-     * @override
-     */
-    get className() {
-        const result = this._super();
-        if (odoo.web_chatter_position === "sided") {
-            result["flex-row"] = true;
-        }
-        return result;
     },
 });


### PR DESCRIPTION
Vì `auto` mặc định là bên cạnh, và chuyển xuống dưới nếu màn hình nhỏ
Còn `sided` thì luôn bên cạnh, và không hỗ trợ response => không có giá trị, nên xóa để người dùng đỡ bối rối và chuyển auto -> sided
