### PR TITLE
[FIX][16.0] web_responsive: log note overflow into content

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -100,7 +100,6 @@ html .o_web_client .o_action_manager .o_action {
     .o_form_editable {
         .o_form_sheet {
             max-width: calc(100% - 32px) !important;
-            overflow-x: auto;
         }
 
         .o_cell .o_form_label:not(.o_status):not(.o_calendar_invitation) {


### PR DESCRIPTION
ticket: https://viindoo.com/web#id=50477&cids=1&menu_id=777&action=1074&active_id=39&model=viin.helpdesk.ticket&view_type=form

-step to reproduce: create a randome with random content, log note to it with some long content, if you are using chatter position is bottom, you can only see the log note because its cover all the content -In this commit we remove overflow-x: auto; in css

Video before and after:

https://github.com/Viindoo/branding/assets/56789189/973d568c-dca9-4375-ad02-4123db966cc9

