### PR TITLE
[IMP][16.0] web_responsive: broken dropdown in mobile search box

### DIFF
--- a/web_responsive/static/src/components/control_panel/control_panel.scss
+++ b/web_responsive/static/src/components/control_panel/control_panel.scss
@@ -155,9 +155,6 @@
         .o_searchview_input_container > .o_searchview_autocomplete {
             left: 0;
             right: 0;
-            > li {
-                padding: 10px 0px;
-            }
         }
         .o_searchview_quick {
             display: flex;


### PR DESCRIPTION
This revert code has missed in commit
47ddbd2e63a61ba9ae11797690bf844eb850027e