### PR TITLE
[FIX] [16.0] web_responsive: fix hide toolbar

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -369,12 +369,6 @@ html .o_web_client .o_action_manager .o_action {
     }
 }
 
-body:not(.o_statusbar_buttons) {
-    .oe-toolbar {
-        z-index: 0 !important;
-    }
-}
-
 .o_inner_group > .mb-sm-0 {
     margin-bottom: 0 !important;
 }


### PR DESCRIPTION
Khi cài module này, bị mất toolbar edit trong hộp soạn văn bản

Đã fix:

![image](https://github.com/Viindoo/branding/assets/71593331/3a9e33df-221c-430e-b707-94c2febec111)
