### PR TITLE
[IMP] [16.0] viin_brand_common: restore default css fw-bold

### DIFF
--- a/viin_brand_common/static/src/webclient/webclient.scss
+++ b/viin_brand_common/static/src/webclient/webclient.scss
@@ -21,3 +21,7 @@
 b, strong {
     font-weight: $font-weight-bolder;
 }
+
+.fw-bold {
+    font-weight: 700 !important;
+}


### PR DESCRIPTION
ticket [ticket](https://viindoo.com/web#id=51009&cids=1&menu_id=777&action=1075&model=viin.helpdesk.ticket&view_type=form)

https://github.com/Viindoo/branding/assets/71593331/08f80dcf-8705-4890-9da7-43092801359d

Khi click vào item của menu search panel, item không có thay đổi khỉến người dùng không biết đang chọn item nào. Pr này tăng độ đậm của item khi click vào