### PR TITLE
[MISC][17.0] *: remove some unnecessary manifest key due to the odoo test_manifest

### DIFF
--- a/to_backend_theme/__manifest__.py
+++ b/to_backend_theme/__manifest__.py
@@ -42,9 +42,7 @@ Backend theme for Viindoo, based on the Openworx Backend Theme
             'to_backend_theme/static/src/scss/style.scss',
             ],
         },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set ['web'] after upgrading to v17
+    'installable': False, # set auto_install to ['web'] after upgrading to v17
     'price': 99.9,
     'currency': 'EUR',
     'license': 'LGPL-3',

--- a/viin_brand/__manifest__.py
+++ b/viin_brand/__manifest__.py
@@ -38,11 +38,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
     'category': 'Hidden',
     'version': '0.1',
     'depends': ['base'],
-    'data': [
-    ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 9.9,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_account/__manifest__.py
+++ b/viin_brand_account/__manifest__.py
@@ -58,9 +58,7 @@ Module này sẽ thay đổi giao diện module Invoicing theo thương hiệu V
         'views/terms_template.xml',
         'wizard/account_tour_upload_bill.xml'
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_auth_oauth/__manifest__.py
+++ b/viin_brand_auth_oauth/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện module OAuth2 Authentication theo thư�
         'views/res_config_settings_views.xml',
         'data/auth_oauth_data.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_auth_totp/__manifest__.py
+++ b/viin_brand_auth_totp/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication theo t
         'views/user_perferences.xml',
         'views/templates.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_auth_totp_mail_enforce/__manifest__.py
+++ b/viin_brand_auth_totp_mail_enforce/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication By Mai
     'data': [
         'views/templates.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_auth_totp_portal/__manifest__.py
+++ b/viin_brand_auth_totp_portal/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module TOTPortal theo thương hiệu V
     'data': [
         'views/templates.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_base_import/__manifest__.py
+++ b/viin_brand_base_import/__manifest__.py
@@ -55,9 +55,7 @@ Module này sẽ thay đổi giao diện module Base import theo thương hiệu
             'viin_brand_base_import/static/src/legacy/xml/base_import.xml',
             ]
     },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_base_setup/__manifest__.py
+++ b/viin_brand_base_setup/__manifest__.py
@@ -58,9 +58,7 @@ Module này sẽ thay đổi giao diện module Initial Setup Tools theo thươn
             'viin_brand_base_setup/static/src/xml/res_config_edition.xml',
         ],
     },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_calendar/__manifest__.py
+++ b/viin_brand_calendar/__manifest__.py
@@ -47,9 +47,7 @@ Module này sẽ thay đổi giao diện module Calendar theo thương hiệu Vi
     'data': [
         'views/calendar_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -83,9 +83,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
             ('after', 'web/static/src/legacy/scss/views.scss', 'viin_brand_common/static/src/legacy/scss/views.scss'),
         ],
     },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set ['web'] after upgrading to v17
+    'installable': False, # set ['web'] after upgrading to v17
     'price': 9.9,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_contacts/__manifest__.py
+++ b/viin_brand_contacts/__manifest__.py
@@ -47,9 +47,7 @@ Module này sẽ thay đổi giao diện module Contacts theo thương hiệu Vi
     'data': [
         'views/contact_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_crm/__manifest__.py
+++ b/viin_brand_crm/__manifest__.py
@@ -55,9 +55,7 @@ Module này sẽ thay đổi giao diện module CRM theo thương hiệu Viindoo
         'views/crm_lead_views.xml',
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_digest/__manifest__.py
+++ b/viin_brand_digest/__manifest__.py
@@ -56,9 +56,7 @@ Module này sẽ thay đổi giao diện module Digest theo thương hiệu Viin
         'views/res_config_settings_views.xml',
         'views/digest_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_fleet/__manifest__.py
+++ b/viin_brand_fleet/__manifest__.py
@@ -48,9 +48,7 @@ Module này sẽ thay đổi giao diện module Fleet theo thương hiệu Viind
         'views/fleet_board_view.xml',
         'views/fleet_vehicle_cost_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_hr/__manifest__.py
+++ b/viin_brand_hr/__manifest__.py
@@ -56,9 +56,7 @@ Module này sẽ thay đổi giao diện module Employees theo thương hiệu V
         'views/hr_employee_public_views.xml',
         'views/hr_employee_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_hr_expense/__manifest__.py
+++ b/viin_brand_hr_expense/__manifest__.py
@@ -59,9 +59,7 @@ Module này sẽ thay đổi giao diện module Hr Expense theo thương hiệu 
             'viin_brand_hr_expense/static/src/scss/viin_brand_hr_expense.scss',
         ],
     },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_hr_recruitment/__manifest__.py
+++ b/viin_brand_hr_recruitment/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện module Hr Expense theo thương hiệu 
         'views/hr_recruitment_views.xml',
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_hr_skills/__manifest__.py
+++ b/viin_brand_hr_skills/__manifest__.py
@@ -43,9 +43,7 @@ Module này sẽ thay đổi giao diện module Skills Management theo thương 
     'data': [
         'views/hr_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_iap/__manifest__.py
+++ b/viin_brand_iap/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module In-App Purchases theo thương h
     'data': [
         'views/res_config_settings.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_im_livechat/__manifest__.py
+++ b/viin_brand_im_livechat/__manifest__.py
@@ -52,9 +52,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -67,9 +67,7 @@ Editions Supported
             ('after', 'mail/static/src/components/thread_view_topbar/thread_view_topbar.scss', 'viin_brand_mail/static/src/components/thread_view_topbar/thread_view_topbar.scss'),
         ],
     },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 9.9,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mail_bot/__manifest__.py
+++ b/viin_brand_mail_bot/__manifest__.py
@@ -43,9 +43,7 @@ Module này sẽ thay đổi giao diện module Mail Bot theo thương hiệu Vi
 
     # any module necessary for this one to work correctly
     'depends': ['mail_bot', 'viin_brand_common'],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mail_plugin/__manifest__.py
+++ b/viin_brand_mail_plugin/__manifest__.py
@@ -42,9 +42,7 @@ Editions Supported
     'data': [
         'views/mail_plugin_login.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 9.9,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mass_mailing/__manifest__.py
+++ b/viin_brand_mass_mailing/__manifest__.py
@@ -63,9 +63,7 @@ Module này sẽ thay đổi giao diện các module Email Marketing theo thươ
     'demo': [
         'data/mass_mailing_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mass_mailing_crm/__manifest__.py
+++ b/viin_brand_mass_mailing_crm/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Lead / Oppo
     'demo': [
         'data/mass_mailing_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mass_mailing_sale/__manifest__.py
+++ b/viin_brand_mass_mailing_sale/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Sale Orders
     'demo': [
         'data/mass_mailing_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mass_mailing_sms/__manifest__.py
+++ b/viin_brand_mass_mailing_sms/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module SMS Marketing theo thương
     'data': [
         'views/mailing_list_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mass_mailing_themes/__manifest__.py
+++ b/viin_brand_mass_mailing_themes/__manifest__.py
@@ -42,9 +42,7 @@ Module này sẽ thay đổi giao diện module Mass Mailing Themes theo thươn
     'data': [
         'views/mass_mailing_themes_templates.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_membership/__manifest__.py
+++ b/viin_brand_membership/__manifest__.py
@@ -47,9 +47,7 @@ Module này sẽ thay đổi giao diện module Members theo thương hiệu Vii
     'data': [
         'views/partner_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mrp/__manifest__.py
+++ b/viin_brand_mrp/__manifest__.py
@@ -55,9 +55,7 @@ Module này sẽ thay đổi giao diện các module Manufacturing theo thương
         'views/res_config_settings_views.xml',
         'wizard/mrp_immediate_production_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_note/__manifest__.py
+++ b/viin_brand_note/__manifest__.py
@@ -47,9 +47,7 @@ Module này sẽ thay đổi giao diện module Notes theo thương hiệu Viind
     'demo': [
         'data/note_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_payment/__manifest__.py
+++ b/viin_brand_payment/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện các module Payment Provider theo thư�
         'views/payment_provider_views.xml',
         'wizards/payment_provider_onboarding_templates.xml'
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_payment_authorize/__manifest__.py
+++ b/viin_brand_payment_authorize/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Authorize.Net Payment Acqui
     'data': [
         'views/payment_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'currency': 'EUR',
     'license': 'OPL-1',
 }

--- a/viin_brand_payment_paypal/__manifest__.py
+++ b/viin_brand_payment_paypal/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Paypal Payment Acquirer the
     'data': [
         'views/payment_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_portal/__manifest__.py
+++ b/viin_brand_portal/__manifest__.py
@@ -47,9 +47,7 @@ Module này sẽ thay đổi giao diện các module Portal theo thương hiệu
     'data': [
         'views/portal_templates.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_pos/__manifest__.py
+++ b/viin_brand_pos/__manifest__.py
@@ -63,9 +63,7 @@ Module này sẽ thay đổi màu sắc của thanh điều hướng (navbar), c
             'viin_brand_pos/static/src/xml/CustomerFacingDisplayOrder.xml',
         ],
     },
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_pos_mercury/__manifest__.py
+++ b/viin_brand_pos_mercury/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Vantiv Payment Services the
     'data': [
         'views/pos_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_product/__manifest__.py
+++ b/viin_brand_product/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện các module Product theo thương hiệ
         'views/res_config_settings_views.xml',
         'views/product_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_purchase/__manifest__.py
+++ b/viin_brand_purchase/__manifest__.py
@@ -55,9 +55,7 @@ Module này sẽ thay đổi giao diện các module Purchase theo thương hi�
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_purchase_stock/__manifest__.py
+++ b/viin_brand_purchase_stock/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Purchase Stock theo thươn
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale/__manifest__.py
+++ b/viin_brand_sale/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện các module Sale theo thương hiệu V
         'views/res_config_settings_views.xml',
         'views/sale_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale_management/__manifest__.py
+++ b/viin_brand_sale_management/__manifest__.py
@@ -54,9 +54,7 @@ Module này sẽ thay đổi giao diện các module Sales theo thương hiệu 
         'data/digest_data.xml',
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale_quotation_builder/__manifest__.py
+++ b/viin_brand_sale_quotation_builder/__manifest__.py
@@ -49,9 +49,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_sale_stock/__manifest__.py
+++ b/viin_brand_sale_stock/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện các module Sale-Stock theo thương hi
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_snailmail/__manifest__.py
+++ b/viin_brand_snailmail/__manifest__.py
@@ -55,9 +55,7 @@ Module này sẽ thay đổi giao diện các module Snail Mail theo thương hi
     },
 
 
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_social_media/__manifest__.py
+++ b/viin_brand_social_media/__manifest__.py
@@ -51,9 +51,7 @@ Module này sẽ thay đổi giao diện các module Social Media theo thương 
     'demo': [
         'demo/res_company_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_stock/__manifest__.py
+++ b/viin_brand_stock/__manifest__.py
@@ -57,9 +57,7 @@ Module này sẽ thay đổi giao diện các module Stock theo thương hiệu 
         'views/stock_location_views.xml',
         'wizard/stock_immediate_transfer_views.xml'
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_stock_account/__manifest__.py
+++ b/viin_brand_stock_account/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện Stock-Account theo thương hiệu Viin
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_web_unsplash/__manifest__.py
+++ b/viin_brand_web_unsplash/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện cuả Unsplash Image Library theo thư�
     'data': [
         'views/res_config_settings_view.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -58,9 +58,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_event/__manifest__.py
+++ b/viin_brand_website_event/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module Events theo thương hiệu Viin
     'demo': [
         'data/event_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_event_exhibitor/__manifest__.py
+++ b/viin_brand_website_event_exhibitor/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module Event Exhibitors theo thương h
     'demo': [
         'data/event_sponsor_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_forum/__manifest__.py
+++ b/viin_brand_website_forum/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module Forum theo thương hiệu Viind
     'demo': [
         'data/forum_demo.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_links/__manifest__.py
+++ b/viin_brand_website_links/__manifest__.py
@@ -53,9 +53,7 @@ Module này sẽ thay đổi giao diện module Link Tracker theo thương hiệ
     'data': [
         'views/website_links_template.xml',
     ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_livechat/__manifest__.py
+++ b/viin_brand_website_livechat/__manifest__.py
@@ -57,9 +57,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set True after upgrading for v17
+    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_profile/__manifest__.py
+++ b/viin_brand_website_profile/__manifest__.py
@@ -52,9 +52,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set ['website_profile'] after upgrading to v17
+    'installable': False, # set ['website_profile'] after upgrading to v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_sale/__manifest__.py
+++ b/viin_brand_website_sale/__manifest__.py
@@ -49,9 +49,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False, # set ['website_sale'] after upgrading to v17
+    'installable': False, # set ['website_sale'] after upgrading to v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_website_slides/__manifest__.py
+++ b/viin_brand_website_slides/__manifest__.py
@@ -53,9 +53,7 @@ Editions Supported
     'images': [
         # 'static/description/main_screenshot.png'
         ],
-    'installable': False,
-    'application': False,
-    'auto_install': False,  # set ['website_slides'] after upgrading to v17
+    'installable': False,  # set ['website_slides'] after upgrading to v17
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',


### PR DESCRIPTION

![image](https://github.com/Viindoo/branding/assets/56789189/162ba010-baed-4db5-abec-8189dac14ebd)


-Odoo has test_manifest value at
https://github.com/Viindoo/odoo/blob/882c8526030c6fee178f2c2026cc0ca80f6de2fd/odoo/addons/test_lint/tests/test_manifests.py#L49 , we should define manifest key that have same default value