### PR TITLE
[FIX][16,0] web_responsive: don't hide attachment preview by default

### DIFF
--- a/web_responsive/static/src/views/form/form_controller.esm.js
+++ b/web_responsive/static/src/views/form/form_controller.esm.js
@@ -8,7 +8,7 @@ import {FormController} from "@web/views/form/form_controller";
 // Patch FormController to always load attachment alongwith the chatter on the side bar
 patch(FormController.prototype, "web_responsive.FormController", {
     setup() {
+        // TODO: remove me in v17/master because viindoo Saas has been suffered errors from some removed JS files in stable version
         this._super();
-        this.hasAttachmentViewerInArch = false;
     },
 });


### PR DESCRIPTION
-OCA already have discussion at `https://github.com/OCA/web/pull/2695`