### PR TITLE
[IMP] viin_brand_common: increase o-root-font-base to 16px

### DIFF
--- a/viin_brand_common/static/src/scss/primary_variables.scss
+++ b/viin_brand_common/static/src/scss/primary_variables.scss
@@ -1,4 +1,5 @@
 $o-root-font-size: 16px;
+$o-font-size-base: 16rem * (1px / $o-root-font-size);
 
 // Change colors here
 $o-community-color: #00bbce;


### PR DESCRIPTION
Trước
![Screenshot from 2024-03-15 15-34-18](https://github.com/Viindoo/branding/assets/43790414/1f9af9e2-6db6-44af-aa13-4eefc5bc037f)![Screenshot from 2024-03-15 15-40-12](https://github.com/Viindoo/branding/assets/43790414/edbfe9a4-b098-4e8c-b7a8-2a1b2fccde96)
Sau
![Screenshot from 2024-03-15 15-37-38](https://github.com/Viindoo/branding/assets/43790414/cecfb782-f70a-456f-8ce9-58ac7a136f9d)![Screenshot from 2024-03-15 15-40-17](https://github.com/Viindoo/branding/assets/43790414/5d1a4856-f1bc-414c-90a7-c0f7198ea6f4)



