### PR TITLE
[FWD][master][IMP] viin_brand_mail: imp ui message

### DIFF
--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -58,6 +58,7 @@ Editions Supported
             ('after', 'mail/static/src/components/discuss_sidebar/discuss_sidebar.scss', 'viin_brand_mail/static/src/components/discuss_sidebar/discuss_sidebar.scss'),
             ('after', 'mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.scss', 'viin_brand_mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.scss'),
             ('after', 'mail/static/src/components/message/message.scss', 'viin_brand_mail/static/src/components/message/message.scss'),
+            ('after', 'mail/static/src/components/message/message.xml', 'viin_brand_mail/static/src/components/message/message.xml'),
             ('after', 'mail/static/src/components/persona_im_status_icon/persona_im_status_icon.scss', 'viin_brand_mail/static/src/components/partner_im_status_icon/partner_im_status_icon.scss'),
             ('after', 'mail/static/src/components/thread_view/thread_view.scss', 'viin_brand_mail/static/src/components/thread_view/thread_view.scss'),
             ('after', 'mail/static/src/components/thread_icon/thread_icon.scss', 'viin_brand_mail/static/src/components/thread_icon/thread_icon.scss'),

--- a/viin_brand_mail/static/src/components/message/message.xml
+++ b/viin_brand_mail/static/src/components/message/message.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <!-- TODO: Delete on version 17.0 because this xpath segment is to handle UI errors only encountered on version 16.0 -->
+    <t t-name='BrandMessage' t-inherit="mail.Message" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[hasclass('o_Message_actionListContainer')]" position="attributes">
+            <attribute name="t-attf-class" separator=" " add="{{messaging.device.isSmall and 'position-absolute top-0 end-0 me-3' or ''}}"/>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Task: [[IMP] Hiển thị bad UI nội dung tin nhắn trong hộp thư đến](https://viindoo.com/web#id=51061&cids=1&menu_id=777&action=1074&active_id=10&model=viin.helpdesk.ticket&view_type=form)

- On the mailbox interface, the o_Message_actionListContainer block is invisible, causing it to take up a large amount of the message display area when the display interface is bad.

Hình ảnh trước PR
![Screenshot 2024-03-16 at 8 24 28 AM](https://github.com/Viindoo/branding/assets/41675989/5fe41e6b-7618-4172-8af9-beb97613c3a4)

Kết quả sau PR: 
![Screenshot 2024-03-16 at 8 19 33 AM](https://github.com/Viindoo/branding/assets/41675989/504e90a1-6cba-45f0-8e94-674f6b0c2d1c)

Forward-Port-Of: #443
