### PR TITLE
[IMP][16.0] web_responsive: shows scroll bar with too long message content

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -8,7 +8,7 @@
 {
     "name": "Web Responsive",
     "summary": "Responsive web client, community-supported",
-    "version": "16.0.1.2.4",
+    "version": "16.0.1.2.5",
     "category": "Website",
     "website": "https://github.com/OCA/web",
     "author": "LasLabs, Tecnativa, ITerra, Onestein, "
@@ -48,6 +48,7 @@
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.esm.js",
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.xml",
             "/web_responsive/static/src/views/form/form_controller.scss",
+            "/web_responsive/static/src/components/message/message.xml",
         ],
         "web.assets_tests": [
             "/web_responsive/static/tests/test_patch.js",

--- a/web_responsive/static/src/components/message/message.xml
+++ b/web_responsive/static/src/components/message/message.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Message" t-inherit-mode="extension" owl="1">
+            <xpath expr="//div[hasclass('o_Message')]" position="attributes">
+                <attribute name="t-attf-class" separator=" " add="{{!messaging.device.isSmall and 'overflow-auto' or ''}}"/>
+            </xpath>     
+    </t>
+</templates>


### PR DESCRIPTION
Ticket: [Điều chỉnh thanh cuộn chatter - hiển thị thanh cuộn với nội dung tin nhắn quá dài](https://viindoo.com/web#id=51875&cids=1&menu_id=777&action=1074&active_id=6&model=viin.helpdesk.ticket&view_type=form)

https://github.com/Viindoo/branding/assets/41675989/f5cce53d-649e-48ee-8dcd-b7b73cfd4add



https://github.com/Viindoo/branding/assets/41675989/393def71-72b5-414a-82e7-33caf432baca



