### PR TITLE
[IMP][16.0] web_responsive: Adjust app icon size

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.scss
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.scss
@@ -108,8 +108,8 @@
         }
 
         .o-app-icon {
-            height: auto;
-            max-width: 6rem;
+            width: 70px;
+            height: 70px;
             padding: 0;
         }
 


### PR DESCRIPTION
- Currently the css of the app icon is following the font, making the app icon larger than expected
- Handling css is similar to odoo

Ticket: [Điều chỉnh Icon app](https://viindoo.com/web#id=51912&cids=1&menu_id=777&action=1074&active_id=6&model=viin.helpdesk.ticket&view_type=form)

Hình ảnh trước và sau khi chỉnh sửa

![image](https://github.com/Viindoo/branding/assets/41675989/49408fa1-2ea8-4722-850a-e65f86f69de0)

<img width="1432" alt="Screenshot 2024-04-06 at 2 12 53 PM" src="https://github.com/Viindoo/branding/assets/41675989/4557d752-3e82-4708-9cc3-b06255d8b7a5">

<img width="387" alt="Screenshot 2024-04-06 at 2 48 07 PM" src="https://github.com/Viindoo/branding/assets/41675989/c2c840ba-8f2b-43a3-9b1f-98f210026b13">



