### PR TITLE
[FIX][15.0] viin_brand_im_livechat: don't hard code livechat button and header

### DIFF
--- a/viin_brand_im_livechat/__init__.py
+++ b/viin_brand_im_livechat/__init__.py
@@ -1,0 +1,15 @@
+from odoo import api, SUPERUSER_ID
+from . import models
+
+
+def _update_viindoo_livechat_color(env):
+    livechat_channels = env["im_livechat.channel"].with_context(active_test=False).search([])
+    if livechat_channels:
+        livechat_channels.write({
+            "header_background_color": "#00a4b5",
+            "button_background_color": "#7f4282",
+        })
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _update_viindoo_livechat_color(env)

--- a/viin_brand_im_livechat/__manifest__.py
+++ b/viin_brand_im_livechat/__manifest__.py
@@ -53,6 +53,7 @@ Editions Supported
     'images': [
     	# 'static/description/main_screenshot.png'
     	],
+    'post_init_hook': 'post_init_hook',
     'installable': True,
     'application': False,
     'auto_install': True,

--- a/viin_brand_im_livechat/models/__init__.py
+++ b/viin_brand_im_livechat/models/__init__.py
@@ -1,0 +1,1 @@
+from . import im_livechat_channel

--- a/viin_brand_im_livechat/models/im_livechat_channel.py
+++ b/viin_brand_im_livechat/models/im_livechat_channel.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ImLivechatChannel(models.Model):
+    _inherit = ['im_livechat.channel']
+
+    header_background_color = fields.Char(default="#00a4b5")
+    button_background_color = fields.Char(default="#7f4282")

--- a/viin_brand_im_livechat/static/src/legacy/public_livechat.scss
+++ b/viin_brand_im_livechat/static/src/legacy/public_livechat.scss
@@ -1,6 +1,3 @@
-.o_livechat_button {
-    background-color: $o-brand-primary !important;
-}
 .o_thread_window {
 	.o_composer_text_field {
         line-height: 2em;
@@ -17,6 +14,5 @@
 
 	.o_thread_window_header {
 		height: auto;
-        background-color: darken($brand-primary, 5%) !important;
 	}	
 }


### PR DESCRIPTION
-Problem: User can not config livechat header background color or button color because the change in [1] has hard code css color for them
-Solution: remove the hard code css, move them into default value of field definition and writing migration script to upgrade them of course

[1]: https://github.com/Viindoo/branding/commit/40c50dc521f280ba34ff0bbd3a03171a131e125b