### PR TITLE
[17.0][IMP] viin_brand_common: hide odoo doc link help

### DIFF
--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -82,6 +82,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
             ('after', 'web/static/src/webclient/webclient.js', 'viin_brand_common/static/src/webclient/webclient.js'),
             'viin_brand_common/static/src/webclient/navbar/navbar.scss',
             'viin_brand_common/static/src/webclient/user_menu_item.js',
+            'viin_brand_common/static/src/views/widgets/**/*',
         ],
     },
     'installable': True,

--- a/viin_brand_common/static/src/views/widgets/documentation_link/documentation_link.js
+++ b/viin_brand_common/static/src/views/widgets/documentation_link/documentation_link.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { DocumentationLink } from "@web/views/widgets/documentation_link/documentation_link";
+import { ODOO_VIINDOO_DOCUMENTATION_MAPPING } from './viindoo_mapping_url';
+
+
+patch(DocumentationLink.prototype, {
+    get url() {
+        let original_url = super.url;
+        if (ODOO_VIINDOO_DOCUMENTATION_MAPPING[original_url] !== undefined){
+            return ODOO_VIINDOO_DOCUMENTATION_MAPPING[original_url];
+        }
+        return original_url;
+    }
+});

--- a/viin_brand_common/static/src/views/widgets/documentation_link/documentation_link.xml
+++ b/viin_brand_common/static/src/views/widgets/documentation_link/documentation_link.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="web.DocumentationLink" t-inherit-mode="extension">
+        <xpath expr="//a" position="attributes">
+            <attribute name="t-if">url</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/viin_brand_common/static/src/views/widgets/documentation_link/viindoo_mapping_url.js
+++ b/viin_brand_common/static/src/views/widgets/documentation_link/viindoo_mapping_url.js
@@ -1,0 +1,105 @@
+/** @odoo-module **/
+
+/* Define documentation of odoo which will be replaced by Viindoo one on setting pages only,
+if none found the system will fallback to the original one of odoo
+This approach help we manage nearly all odoo documentation to be replaced or not
+ */
+
+export const ODOO_VIINDOO_DOCUMENTATION_MAPPING = {
+    /* account */
+    "https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/taxation/taxes/default_taxes.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/taxation/taxes/taxcloud.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/taxation/taxes/avatax.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/taxation/taxes/eu_distance_selling.html": "https://viindoo.com/documentation/16.0/applications/finance/accounting-and-invoicing/taxation/distance-selling-for-eu-intra-community.html",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/taxation/taxes/cash_basis_taxes.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/others/multi_currency.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/receivables/customer_invoices/snailmail.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/send_quotations/different_addresses.html": "https://viindoo.com/documentation/16.0/applications/sales/sales/send-quotations/manage-invoicing-address-and-delivery-address-in-sales.html",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/receivables/customer_invoices/cash_rounding.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/reporting/declarations/intrastat.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/receivables/customer_payments/online_payment.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/receivables/customer_payments/batch.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/receivables/customer_payments/batch_sdd.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/receivables/customer_invoices/epc_qr_code.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/payables/pay/check.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/payables/pay/sepa.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/payables/supplier_bills/invoice_digitization.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/others/analytic_accounting.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/others/adviser/budget.html": "",
+    /* auth_oauth */
+    "https://www.odoo.com/documentation/17.0/applications/general/auth/google.html": "https://viindoo.com/documentation/16.0/applications/getting-started/system-settings/sign-in-with-google-authentication.html",
+    /* base_setup */
+    "https://www.odoo.com/documentation/17.0/applications/marketing/sms_marketing/pricing/pricing_and_faq.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/general/export_import_data.html": "https://viindoo.com/documentation/16.0/applications/getting-started/guiding-to-import-and-export-data.html#import-data-into-viindoo-software",
+    "https://www.odoo.com/documentation/17.0/applications/productivity/mail_plugins.html": "https://viindoo.com/documentation/16.0/applications/getting-started.html",
+    "https://www.odoo.com/documentation/17.0/applications/general/auth/ldap.html": "https://viindoo.com/documentation/16.0/applications/getting-started/external-apps-integration/ldap.html?highlight=ldap",
+    "https://www.odoo.com/documentation/17.0/applications/websites/website/optimize/unsplash.html": "https://viindoo.com/documentation/16.0/applications/websites/website/optimize/how-to-intergrate-with-free-image-library-at-unsplash.html",
+    /* base_vat */
+    "https://www.odoo.com/documentation/17.0/applications/finance/accounting/taxation/taxes/vat_validation.html": "",
+    /* calendar */
+    "https://www.odoo.com/documentation/17.0/applications/productivity/calendar/outlook.html": "https://viindoo.com/documentation/16.0/applications/productivity/calendar/sychronization-with-outlook-s-calendar.html",
+    "https://www.odoo.com/documentation/17.0/applications/productivity/calendar/google.html": "https://viindoo.com/documentation/16.0/applications/productivity/calendar/sychronization-with-google-s-calendar.html",
+    /* crm */
+    "https://www.odoo.com/documentation/17.0/applications/sales/crm/track_leads/lead_scoring.html#assign-leads": "",
+    "https://www.odoo.com/documentation/17.0/applications/sales/crm/acquire_leads/lead_mining.html": "",
+    /* digest */
+    "https://www.odoo.com/documentation/17.0/applications/general/digest_emails.html": "",
+    /* event */
+    /* hr_recruitment */
+    /* hr_timesheet */
+    "https://www.odoo.com/documentation/17.0/applications/services/timesheets/overview/time_off.html": "",
+    /* iap */
+    "https://www.odoo.com/documentation/17.0/applications/general/in_app_purchase.html": "",
+    /* mail */
+    "https://www.odoo.com/documentation/17.0/applications/general/email_communication/email_servers.html": "https://viindoo.com/documentation/16.0/applications/getting-started/system-settings/how-to-set-mail-server-for-sending-receiving-emails-in-viindoo.html",
+    "https://www.odoo.com/documentation/17.0/applications/general/email_communication/email_domain.html#be-spf-compliant": "",
+    /* mrp */
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/manufacturing/management/bill_configuration.html#adding-a-routing": "https://viindoo.com/documentation/16.0/applications/supply-chain/manufacturing/products/how-to-create-bills-of-materials.html",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/manufacturing/management/subcontracting.html": "https://viindoo.com/documentation/16.0/applications/supply-chain/manufacturing/operations/manage-subcontracts-in-your-manufacturing-proccess.html",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/manufacturing/management/use_mps.html": "https://viindoo.com/documentation/16.0/applications/supply-chain/manufacturing/planning/how-to-use-the-master-production-schedule-in-viindoo.html",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html": "https://viindoo.com/documentation/16.0/applications/supply-chain/inventory/warehouse-management/planning/understanding-the-scheduled-delivery-date-computation.html",
+    /* point_of_sale */
+    "https://www.odoo.com/documentation/17.0/applications/sales/point_of_sale/pricing/cash_rounding.html": "https://viindoo.com/documentation/16.0/applications/finance/accounting-and-invoicing/account-receivables/customer-invoices/settings/configure-cash-rounding-method.html",
+    "https://www.odoo.com/documentation/17.0/applications/sales/point_of_sale/payment_methods/terminals/vantiv.html": "https://viindoo.com/documentation/16.0/applications/sales/point-of-sale/pricing-features/payment-with-vantiv-payment-terminal-in-pos.html",
+    "https://www.odoo.com/documentation/17.0/applications/sales/point_of_sale/payment_methods/terminals/six.html": "https://viindoo.com/documentation/16.0/applications/sales/point-of-sale/pricing-features/payment-with-six-payment-terminal-in-pos.html",
+    /* product */
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/products_prices/products/product_images.html": "",
+    /* purchase */
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/purchase/manage_deals/agreements.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/purchase/manage_deals/control_bills.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/products/uom.html": "",
+    /* purchase_stock */
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/operation/dropshipping.html": "",
+    /* sale */
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/products_prices/products/variants.html": "https://viindoo.com/documentation/16.0/applications/getting-started/products/using-product-variants-in-viindoo.html",
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/products_prices/prices/pricing.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/invoicing/invoicing_policy.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/invoicing/down_payment.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/amazon_connector/setup.html": "",
+    /* sale_management */
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/send_quotations/quote_template.html": "",
+    /* sale_pdf_quote_builder */
+    "https://www.odoo.com/documentation/17.0/applications/sales/sales/send_quotations/pdf_quote_builder.html": "",
+    /* sale_stock */
+    /* stock */
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/products/usage.html#packages": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/misc/batch_transfers.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/manufacturing/management/quality_control.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/barcode/setup/software.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/products/usage.html#packaging": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/lots_serial_numbers/differences.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/lots_serial_numbers/expiration_dates.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/misc/owned_stock.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/warehouses/warehouses_locations.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/routes/concepts/use_routes.html": "",
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/delivery/dropshipping.html": "",
+    /* stock_account */
+    "https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/management/reporting/integrating_landed_costs.html": "",
+    /* web_unsplash */
+    "https://www.odoo.com/documentation/17.0/applications/websites/website/optimize/unsplash.html#generate-an-unsplash-access-key": "",
+    /* website */
+    "https://www.odoo.com/documentation/17.0/applications/websites/website/configuration/cookies_bar.html": "",
+    /* website_sale */
+};


### PR DESCRIPTION
* Problem
  - All odoo links need to be replaced manually with xpath.
  - That will make it difficult to manage links and increase the
maintenance burden
  - In addition, it also reduces the effectiveness of de branding

* Solution
  - Gather odoo's links in a single data file, then replace it with our
link
  - For links that are not ready, they will be hidden. If it is not in
the datas, the odoo link will be taken, the user will know it will
detect it and make an addition



https://github.com/Viindoo/branding/assets/95740163/344cea81-5d35-49c9-8e5b-3f20fce3ed13



