### PR TITLE
[FIX][16.0] viin_brand_mail: fix branding and export translation

### DIFF
--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -34,7 +34,7 @@ Editions Supported
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",
     'category': 'Hidden',
-    'version': '0.1.0',
+    'version': '0.1.1',
 
     # any module necessary for this one to work correctly
     'depends': ['mail', 'viin_brand_common'],

--- a/viin_brand_mail/i18n/vi_VN.po
+++ b/viin_brand_mail/i18n/vi_VN.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-31 01:50+0000\n"
 "PO-Revision-Date: 2022-04-24 09:44+0000\n"
@@ -17,7 +17,6 @@ msgstr ""
 
 #. module: viin_brand_mail
 #: model:ir.model.fields,field_description:viin_brand_mail.field_mail_alias__alias_name
-#: model:ir.model.fields,field_description:viin_brand_mail.field_mail_channel__alias_name
 msgid "Alias Name"
 msgstr "Tên bí danh"
 
@@ -27,9 +26,14 @@ msgid "Email Aliases"
 msgstr "Bí danh Email"
 
 #. module: viin_brand_mail
+#: model:ir.model,name:viin_brand_mail.model_ir_http
+msgid "HTTP Routing"
+msgstr "Định tuyến HTTP"
+
+#. module: viin_brand_mail
 #: model:ir.model.fields.selection,name:viin_brand_mail.selection__res_users__notification_type__inbox
 msgid "Handle in Viindoo"
-msgstr "Xử lí trong hệ thống"
+msgstr "Xử lý trong hệ thống"
 
 #. module: viin_brand_mail
 #: model:ir.model.fields,field_description:viin_brand_mail.field_res_users__notification_type
@@ -40,16 +44,15 @@ msgstr "Thông báo"
 #: model:ir.model.fields,help:viin_brand_mail.field_res_users__notification_type
 msgid ""
 "Policy on how to handle Chatter notifications:\n"
-"- Handle by Emails: notifications are sent to your email address\n"
-"- Handle in Odoo: notifications appear in your Odoo Inbox"
+"- Handle by Emails: notifications appear in your Viindoo Inbox and are sent to your email at the same time\n"
+"- Handle in Viindoo: notifications appear in your Viindoo Inbox"
 msgstr ""
 "Chính sách cho cách thức xử lý các thông báo Chatter:\n"
-"- Xử lý bằng email: các thông báo được gửi đến địa chỉ email của bạn\n"
-"- Xử lý trong hệ thống: các thông báo xuất hiện trong Hộp thư đến trong hệ thống"
+"- Xử lý bằng Email: các thông báo sẽ xuất hiện trong hộp thư đến của hệ thống và đồng thời được gửi đến địa chỉ email của bạn\n"
+"- Xử lý trong Hệ thống: các thông báo xuất hiện trong Hộp thư đến trong hệ thống"
 
 #. module: viin_brand_mail
 #: model:ir.model.fields,help:viin_brand_mail.field_mail_alias__alias_name
-#: model:ir.model.fields,help:viin_brand_mail.field_mail_channel__alias_name
 msgid ""
 "The name of the email alias, e.g. 'jobs' if you want to catch emails for "
 "<jobs@example.viindoo.com>"
@@ -59,7 +62,7 @@ msgstr ""
 
 #. module: viin_brand_mail
 #: model:ir.model,name:viin_brand_mail.model_res_users
-msgid "Users"
+msgid "User"
 msgstr "Người dùng"
 
 #. module: viin_brand_mail
@@ -74,12 +77,21 @@ msgstr ""
 " từ máy chủ email sẵn sàng sử dụng (@tencongty.viindoo.com)."
 
 #. module: viin_brand_mail
-#: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_borders
+#: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_layout
 #: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_light
-#: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_paynow
-#: model_terms:ir.ui.view,arch_db:viin_brand_mail.message_notification_email
 msgid "Viindoo"
+msgstr "Hệ thống Viindoo"
+
+#. module: viin_brand_mail
+#. odoo-javascript
+#: code:addons/viin_brand_mail/static/src/components/notification_alert/notification_alert.xml:0
+#, python-format
+msgid ""
+"Viindoo Push notifications have been blocked. Go to your browser settings to"
+" allow them."
 msgstr ""
+"Gửi thông báo trong Viindoo đã bị chặn. Vui lòng đến phẩn cài đặt của trình "
+"duyệt để kích hoạt."
 
 #. module: viin_brand_mail
 #: model_terms:ir.ui.view,arch_db:viin_brand_mail.res_config_settings_view_form

--- a/viin_brand_mail/i18n/viin_brand_mail.pot
+++ b/viin_brand_mail/i18n/viin_brand_mail.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-31 01:50+0000\n"
-"PO-Revision-Date: 2022-04-24 09:43+0000\n"
+"POT-Creation-Date: 2021-05-31 01:50+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,13 +17,17 @@ msgstr ""
 
 #. module: viin_brand_mail
 #: model:ir.model.fields,field_description:viin_brand_mail.field_mail_alias__alias_name
-#: model:ir.model.fields,field_description:viin_brand_mail.field_mail_channel__alias_name
 msgid "Alias Name"
 msgstr ""
 
 #. module: viin_brand_mail
 #: model:ir.model,name:viin_brand_mail.model_mail_alias
 msgid "Email Aliases"
+msgstr ""
+
+#. module: viin_brand_mail
+#: model:ir.model,name:viin_brand_mail.model_ir_http
+msgid "HTTP Routing"
 msgstr ""
 
 #. module: viin_brand_mail
@@ -40,13 +44,12 @@ msgstr ""
 #: model:ir.model.fields,help:viin_brand_mail.field_res_users__notification_type
 msgid ""
 "Policy on how to handle Chatter notifications:\n"
-"- Handle by Emails: notifications are sent to your email address\n"
-"- Handle in Odoo: notifications appear in your Odoo Inbox"
+"- Handle by Emails: notifications appear in your Viindoo Inbox and are sent to your email at the same time\n"
+"- Handle in Viindoo: notifications appear in your Viindoo Inbox"
 msgstr ""
 
 #. module: viin_brand_mail
 #: model:ir.model.fields,help:viin_brand_mail.field_mail_alias__alias_name
-#: model:ir.model.fields,help:viin_brand_mail.field_mail_channel__alias_name
 msgid ""
 "The name of the email alias, e.g. 'jobs' if you want to catch emails for "
 "<jobs@example.viindoo.com>"
@@ -54,7 +57,7 @@ msgstr ""
 
 #. module: viin_brand_mail
 #: model:ir.model,name:viin_brand_mail.model_res_users
-msgid "Users"
+msgid "User"
 msgstr ""
 
 #. module: viin_brand_mail
@@ -66,11 +69,18 @@ msgid ""
 msgstr ""
 
 #. module: viin_brand_mail
-#: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_borders
+#: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_layout
 #: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_light
-#: model_terms:ir.ui.view,arch_db:viin_brand_mail.mail_notification_paynow
-#: model_terms:ir.ui.view,arch_db:viin_brand_mail.message_notification_email
 msgid "Viindoo"
+msgstr ""
+
+#. module: viin_brand_mail
+#. odoo-javascript
+#: code:addons/viin_brand_mail/static/src/components/notification_alert/notification_alert.xml:0
+#, python-format
+msgid ""
+"Viindoo Push notifications have been blocked. Go to your browser settings to"
+" allow them."
 msgstr ""
 
 #. module: viin_brand_mail

--- a/viin_brand_mail/views/mail_data.xml
+++ b/viin_brand_mail/views/mail_data.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 	<template id="mail_notification_light" inherit_id="mail.mail_notification_light">
-		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="attributes">
-			<attribute name="style">display:none</attribute>
+		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="replace" mode="inner">
+			Viindoo
 		</xpath>
-		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="after">
-			<a target="_blank" href="https://viindoo.com?utm_source=db&amp;utm_medium=email" style="color: #66C8D3;">Viindoo</a>
+		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="attributes">
+			<attribute name="style">color: #66C8D3;</attribute>
+			<attribute name="href">https://viindoo.com?utm_source=db&amp;utm_medium=email</attribute>
 		</xpath>
 	</template>
 	<template id="mail_notification_layout" inherit_id="mail.mail_notification_layout">
-		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="attributes">
-			<attribute name="style">display:none</attribute>
+		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="replace" mode="inner">
+			Viindoo
 		</xpath>
-		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="after">
-			<a target="_blank" href="https://viindoo.com?utm_source=db&amp;utm_medium=email" style="color: #66C8D3;">Viindoo</a>
+		<xpath expr="//a[@href='https://www.odoo.com?utm_source=db&amp;utm_medium=email']" position="attributes">
+			<attribute name="style">color: #66C8D3;</attribute>
+			<attribute name="href">https://viindoo.com?utm_source=db&amp;utm_medium=email</attribute>
 		</xpath>
 	</template>
 </odoo>


### PR DESCRIPTION
-Problem: display none might not work on some browser or email app, which might cause some branding lost like in this ticket https://viindoo.com/web#id=52961&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form
-Solution: instead of using display none to hide odoo stuff, we replace it completely using replace mode inner and attribute replacement

Trước đây: Vẫn còn element thẻ a của odoo nhưng bị `display:none`
![2024-07-05_13-10](https://github.com/Viindoo/branding/assets/56789189/73edc5ba-d6eb-458d-9ebd-35f5fd71ebc1)
Sau khi fix thì element Odoo đã biến mất
![2024-07-05_13-10_1](https://github.com/Viindoo/branding/assets/56789189/dd23ac88-a7ec-413c-b7c8-6e23f3b9f6f2)
