### PR TITLE
[UPG + ADD] viin_brand_mail_bot*: upgrade to version 17.0

### DIFF
--- a/viin_brand_im_livechat_mail_bot/__init__.py
+++ b/viin_brand_im_livechat_mail_bot/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/viin_brand_im_livechat_mail_bot/__manifest__.py
+++ b/viin_brand_im_livechat_mail_bot/__manifest__.py
@@ -1,0 +1,51 @@
+{
+    'name': "Im Live Chat Mail Bot Debranding for Viindoo",
+    'name_vi_VN': "Giao diện Viindoo cho module Tôi là Chat Bot Trực tuyến",
+
+    'summary': """
+Debranding Im Live Chat Mail Bot for Viindoo
+    """,
+    'summary_vi_VN': """
+Giao diện brand Viindoo cho module Tôi là Chat Bot Trực tuyến
+    """,
+
+    'description': """
+What it does
+============
+This module will change brand in Im Live Chat Mail Bot following Viindoo's brand
+
+Editions Supported
+==================
+1. Community Edition
+2. Enterprise Edition
+
+    """,
+
+    'description_vi_VN': """
+Ứng dụng này làm gì
+===================
+Module này sẽ thay đổi giao diện module Tôi là Chat Bot Trực tuyến theo thương hiệu Viindoo
+
+Ấn bản được Hỗ trợ
+==================
+1. Ấn bản Community
+2. Ấn bản Enterprise
+
+    """,
+
+    'author': "Viindoo",
+    'website': "https://viindoo.com",
+    'live_test_url': "https://v16demo-int.viindoo.com",
+    'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
+    'support': "apps.support@viindoo.com",
+    'category': 'Hidden',
+    'version': '0.1.0',
+
+    # any module necessary for this one to work correctly
+    'depends': ['im_livechat_mail_bot', 'viin_brand_common'],
+    'installable': True,
+    'auto_install': True,
+    'price': 0.0,
+    'currency': 'EUR',
+    'license': 'OPL-1',
+}

--- a/viin_brand_im_livechat_mail_bot/i18n/vi_VN.po
+++ b/viin_brand_im_livechat_mail_bot/i18n/vi_VN.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_im_livechat_mail_bot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-09 04:32+0000\n"
+"PO-Revision-Date: 2024-07-09 04:32+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: viin_brand_im_livechat_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_im_livechat_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+"Tuyệt vời, bạn có thể tùy chỉnh câu trả lời mẫu trong ứng dụng trò chuyện "
+"trực tiếp.<br/><br/><b>Đó là cuối cùng của bài viết này</b>, bạn có thể "
+"<b>đóng cuộc trò chuyện</b> hoặc bắt đầu hướng dẫn lại bằng cách gõ <span "
+"class=\"o_odoobot_command\">start the tour</span>. Chúc bạn khám phá Viindoo!"
+
+#. module: viin_brand_im_livechat_mail_bot
+#: model:ir.model,name:viin_brand_im_livechat_mail_bot.model_mail_bot
+msgid "Mail Bot"
+msgstr ""

--- a/viin_brand_im_livechat_mail_bot/i18n/viin_brand_im_livechat_mail_bot.pot
+++ b/viin_brand_im_livechat_mail_bot/i18n/viin_brand_im_livechat_mail_bot.pot
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_im_livechat_mail_bot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-09 04:31+0000\n"
+"PO-Revision-Date: 2024-07-09 04:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: viin_brand_im_livechat_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_im_livechat_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+
+#. module: viin_brand_im_livechat_mail_bot
+#: model:ir.model,name:viin_brand_im_livechat_mail_bot.model_mail_bot
+msgid "Mail Bot"
+msgstr ""

--- a/viin_brand_im_livechat_mail_bot/models/__init__.py
+++ b/viin_brand_im_livechat_mail_bot/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_bot

--- a/viin_brand_im_livechat_mail_bot/models/mail_bot.py
+++ b/viin_brand_im_livechat_mail_bot/models/mail_bot.py
@@ -1,0 +1,23 @@
+import threading
+from markupsafe import Markup
+
+from odoo import models, _
+
+
+class MailBot(models.AbstractModel):
+    _inherit = 'mail.bot'
+
+    def _get_answer(self, record, body, values, command=False):
+        test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
+        if test_mode:
+            return super(MailBot, self)._get_answer(record, body, values, command)
+        else:
+            odoobot_state = self.env.user.odoobot_state
+            if self._is_bot_in_private_channel(record):
+                # help message
+                if odoobot_state == "onboarding_canned" and self.env.context.get("canned_response_ids"):
+                    self.env.user.odoobot_failed = False
+                    self.env.user.odoobot_state = "idle"
+                    return Markup(_("Good, you can customize canned responses in the live chat application.<br/><br/><b>It's the end of this overview</b>, you can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+
+            return super(MailBot, self)._get_answer(record, body, values, command)

--- a/viin_brand_mail_bot/__manifest__.py
+++ b/viin_brand_mail_bot/__manifest__.py
@@ -43,7 +43,8 @@ Module này sẽ thay đổi giao diện module Mail Bot theo thương hiệu Vi
 
     # any module necessary for this one to work correctly
     'depends': ['mail_bot', 'viin_brand_common'],
-    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
+    'installable': True,
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mail_bot/i18n/vi_VN.po
+++ b/viin_brand_mail_bot/i18n/vi_VN.po
@@ -4,16 +4,50 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-13 10:42+0000\n"
-"PO-Revision-Date: 2023-02-13 10:42+0000\n"
+"POT-Creation-Date: 2024-07-09 04:29+0000\n"
+"PO-Revision-Date: 2024-07-09 04:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+"Rất tốt, bạn có thể tùy chỉnh các câu trả lời mẫu trong ứng dụng trò chuyện "
+"trực tiếp.<br/><br/><b>Đây là cuối cùng của bản tổng quan này</b>, bạn có thể"
+" <b>đóng cuộc trò chuyện này</b> hoặc bắt đầu chuyến tham quan lại bằng cách "
+"nhập <span class=\"o_odoobot_command\">start the tour</span>. Hãy thưởng thức "
+"việc khám phá Viindoo!"
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"I am a simple bot, but if that's a dog, he is the cutest 😊 "
+"<br/>Congratulations, you finished this tour. You can now <b>close this "
+"conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+"Tôi chỉ là một robot đơn giản, nhưng nếu đó là một con chó, nó là con chó dễ"
+" thương nhất 😊 <br/>Chúc mừng bạn đã hoàn thành chuyến tham quan này. Bạn có"
+" thể <b>đóng cuộc trò chuyện này</b> hoặc bắt đầu chuyến tham quan lại bằng "
+"cách nhập <span class=\"o_odoobot_command\">start the tour</span>. Hãy "
+"thưởng thức việc khám phá Viindoo!"
 
 #. module: viin_brand_mail_bot
 #: model:ir.model,name:viin_brand_mail_bot.model_mail_bot

--- a/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
+++ b/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
@@ -4,16 +4,40 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-13 10:42+0000\n"
-"PO-Revision-Date: 2023-02-13 10:42+0000\n"
+"POT-Creation-Date: 2024-07-09 04:29+0000\n"
+"PO-Revision-Date: 2024-07-09 04:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"I am a simple bot, but if that's a dog, he is the cutest 😊 "
+"<br/>Congratulations, you finished this tour. You can now <b>close this "
+"conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
 
 #. module: viin_brand_mail_bot
 #: model:ir.model,name:viin_brand_mail_bot.model_mail_bot

--- a/viin_brand_mail_bot/models/mail_bot.py
+++ b/viin_brand_mail_bot/models/mail_bot.py
@@ -1,4 +1,5 @@
 import threading
+from markupsafe import Markup
 
 from odoo import models, _
 
@@ -8,15 +9,24 @@ class MailBot(models.AbstractModel):
 
     def _get_answer(self, record, body, values, command=False):
         test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
-        res = super(MailBot, self)._get_answer(record, body, values, command)
         if test_mode:
-            return res
+            return super(MailBot, self)._get_answer(record, body, values, command)
         else:
             odoobot_state = self.env.user.odoobot_state
             if self._is_bot_in_private_channel(record):
                 # help message
                 if self._is_help_requested(body) or odoobot_state == 'idle':
-                    return _("Unfortunately, I'm just a bot 😞 I don't understand! If you need help discovering our product, please check "
+                    return Markup(_("Unfortunately, I'm just a bot 😞 I don't understand! If you need help discovering our product, please check "
                              "<a href=\"https://www.viindoo.com/documentation\" target=\"_blank\">our documentation</a> or "
-                             "<a href=\"https://www.viindoo.com/slides\" target=\"_blank\">our videos</a>.")
-                return res
+                             "<a href=\"https://www.viindoo.com/slides\" target=\"_blank\">our videos</a>."))
+                elif odoobot_state == 'onboarding_attachement' and values.get("attachment_ids"):
+                    self.env.user.odoobot_state = "idle"
+                    self.env.user.odoobot_failed = False
+                    return Markup(_("I am a simple bot, but if that's a dog, he is the cutest 😊 <br/>Congratulations, you finished this tour. You can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+                # Actually this one should be in im_livechat_mail_bot
+                elif odoobot_state == "onboarding_canned" and self.env.context.get("canned_response_ids"):
+                    self.env.user.odoobot_failed = False
+                    self.env.user.odoobot_state = "idle"
+                    return Markup(_("Good, you can customize canned responses in the live chat application.<br/><br/><b>It's the end of this overview</b>, you can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+
+            return super(MailBot, self)._get_answer(record, body, values, command)


### PR DESCRIPTION
Được tách ra từ
---
- https://github.com/Viindoo/branding/pull/483

Task
---

- [viin_brand_mail_bot](https://viindoo.com/web#id=91589&cids=1&menu_id=289&action=409&active_id=392&model=project.task&view_type=form)

PR này để:
----

Nâng cấp mô đun `viin_brand_mail_bot` lên phiên bản 17.0 và bổ sung thêm mô đun `viin_brand_im_livechat_mail_bot` phục vụ cho việc debranding mô đun `im_livechat_mail_bot` của odoo