### PR TITLE
[17.0][UPG] viin_brand_mass_mailing_sale: upgrade to version 17.0

### DIFF
--- a/viin_brand_mass_mailing_sale/__manifest__.py
+++ b/viin_brand_mass_mailing_sale/__manifest__.py
@@ -53,7 +53,8 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Sale Orders
     'demo': [
         'data/mass_mailing_demo.xml',
     ],
-    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
+    'installable': True,
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mass_mailing_sale/data/mass_mailing_demo.xml
+++ b/viin_brand_mass_mailing_sale/data/mass_mailing_demo.xml
@@ -1,17 +1,6 @@
 <odoo>
     <data noupdate="0">
     <record id="mass_mailing_sale.mass_mail_sale_order_0" model="mailing.mailing">
-        <field name="name">Sale Promotion 1</field>
-        <field name="subject">Our last promotions, just for you !</field>
-        <field name="state">in_queue</field>
-        <field name="user_id" ref="base.user_admin"/>
-        <field name="schedule_date" eval="(DateTime.today() + relativedelta(days=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
-        <field name="campaign_id" ref="mass_mailing.mass_mail_campaign_1"/>
-        <field name="source_id" ref="sale.utm_source_sale_order_0"/>
-        <field name="mailing_model_id" ref="sale.model_sale_order"/>
-        <field name="mailing_domain">[]</field>
-        <field name="reply_to_mode">new</field>
-        <field name="reply_to">{{ object.company_id.email }}</field>
         <field name="body_arch" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 24px; background-color: white; color: #454748; border-collapse:separate;">


### PR DESCRIPTION
[viin_brand_mass_mailing_sale](https://viindoo.com/web#id=91593&cids=1&menu_id=289&action=409&active_id=392&model=project.task&view_type=form)
---

PR này để:
---

- Nâng cấp mô đun `viin_brand_mass_mailing_sale` lên phiên bản 17.0

**Thay đổi**
- Xóa những dòng code không cần xpath đi, giúp việc khi odoo có fix các dữ liệu đó thì mình cũng không cần focus và xử lý cùng


![image](https://github.com/user-attachments/assets/fa2b839e-9b17-4d73-ad05-a8bc36639692)
