### PR TITLE
[17.0][UPG] viin_brand_mail_plugin: upgrade to version 17.0 ( Not change )

### DIFF
--- a/viin_brand_mail_plugin/__manifest__.py
+++ b/viin_brand_mail_plugin/__manifest__.py
@@ -42,7 +42,8 @@ Editions Supported
     'data': [
         'views/mail_plugin_login.xml',
     ],
-    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
+    'installable': True,
+    'auto_install': True,
     'price': 9.9,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mail_plugin/i18n/vi_VN.po
+++ b/viin_brand_mail_plugin/i18n/vi_VN.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 07:57+0000\n"
-"PO-Revision-Date: 2023-10-19 07:57+0000\n"
+"POT-Creation-Date: 2024-07-25 03:59+0000\n"
+"PO-Revision-Date: 2024-07-25 03:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/viin_brand_mail_plugin/i18n/viin_brand_mail_plugin.pot
+++ b/viin_brand_mail_plugin/i18n/viin_brand_mail_plugin.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 07:56+0000\n"
-"PO-Revision-Date: 2023-10-19 07:56+0000\n"
+"POT-Creation-Date: 2024-07-25 03:59+0000\n"
+"PO-Revision-Date: 2024-07-25 03:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
[viin_brand_mail_plugin](https://viindoo.com/web#id=91590&cids=1&menu_id=289&action=409&active_id=392&model=project.task&view_type=form)
---

- Không có gì thay đổi so với bản 16.0

Cách tái hiện:
vào route như hình `mail_client_extension/auth` để kiểm tra hiển thị trước và sau khi debranding

![image](https://github.com/user-attachments/assets/33672e3e-d43b-43fe-a451-6835a152fef4)
