### PR TITLE
[16.0][FIX] viin_brand_stock: action confirm Receipt Slip not translated

### DIFF
--- a/viin_brand_stock/i18n/vi_VN.po
+++ b/viin_brand_stock/i18n/vi_VN.po
@@ -56,11 +56,11 @@ msgstr ""
 "cầu báo giá hoặc các lệnh sản xuất được xác nhận để tái cung ứng cho "
 "kho của bạn."
 
-#. module: stock
-#: model_terms:ir.ui.view,arch_db:stock.view_immediate_transfer
+#. module: viin_brand_stock
+#: model_terms:ir.ui.view,arch_db:viin_brand_stock.view_immediate_transfer
 msgid ""
-"You have not recorded <i>done</i> quantities yet, by clicking on "
-"<i>apply</i> Viindoo will process all the quantities."
+"You have not recorded <i>done</i> quantities yet, by clicking on <i>apply</i>,\n"
+"                    Viindoo will process all the quantities."
 msgstr ""
-"Bạn chưa ghi số lượng <i>thực hiện</i>, bằng cách nhấp vào "
-"<i>áp dụng</i> Viindoo sẽ xử lý tất cả số lượng."
+"Bạn chưa ghi lại số lượng <i>thực hiện</i>, bằng cách nhấn vào <i>áp dụng</i>,\n"
+"                    Viindoo sẽ xử lý tất cả số lượng."

--- a/viin_brand_stock/i18n/viin_brand_stock.pot
+++ b/viin_brand_stock/i18n/viin_brand_stock.pot
@@ -42,9 +42,9 @@ msgid ""
 "quotations or confirmed manufacturing orders to resupply your stock."
 msgstr ""
 
-#. module: stock
-#: model_terms:ir.ui.view,arch_db:stock.view_immediate_transfer
+#. module: viin_brand_stock
+#: model_terms:ir.ui.view,arch_db:viin_brand_stock.view_immediate_transfer
 msgid ""
-"You have not recorded <i>done</i> quantities yet, by clicking on "
-"<i>apply</i> Viindoo will process all the quantities."
+"You have not recorded <i>done</i> quantities yet, by clicking on <i>apply</i>,\n"
+"                    Viindoo will process all the quantities."
 msgstr ""

--- a/viin_brand_stock/wizard/stock_immediate_transfer_views.xml
+++ b/viin_brand_stock/wizard/stock_immediate_transfer_views.xml
@@ -7,7 +7,7 @@
         <field name="priority">110</field>
         <field name="arch" type="xml">
             <xpath expr="//p" position="replace">
-                <p>You have not recorded <i>done</i> quantities yet, by clicking on <i>apply</i>
+                <p>You have not recorded <i>done</i> quantities yet, by clicking on <i>apply</i>,
                     Viindoo will process all the quantities.</p>
             </xpath>
         </field>


### PR DESCRIPTION
[[Translate] Message when confirm Receipt Slip is not translated to Vietnamese](https://viindoo.com/web#id=54070&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form)
---

For this PR:
---

- Sửa lỗi wizard confirm phiếu dịch chuyển không được dịch

![image](https://github.com/user-attachments/assets/582e0915-66af-425b-aff8-46784a37ab2e)
