### PR TITLE
[FIX][17.0] viin_brand_web_editor: fix css

### DIFF
--- a/viin_brand_web_editor/__manifest__.py
+++ b/viin_brand_web_editor/__manifest__.py
@@ -29,13 +29,7 @@ Editions Supported
     'version': '0.1',
     'depends': ['web_editor', 'web'],
     'assets': {
-        'web.assets_backend': [
-            ('after', 'web_editor/static/src/scss/web_editor.common.scss', 'viin_brand_web_editor/static/src/scss/web_editor.common.scss'),
-        ],
         'web.assets_frontend': [
-            ('after', 'web_editor/static/src/scss/web_editor.common.scss', 'viin_brand_web_editor/static/src/scss/web_editor.common.scss'),
-        ],
-        'web.report_assets_common': [
             ('after', 'web_editor/static/src/scss/web_editor.common.scss', 'viin_brand_web_editor/static/src/scss/web_editor.common.scss'),
         ],
     },


### PR DESCRIPTION
- When the statusbar button changes to dropdown, the primary button no longer has a color, the white text will hide on the white background

TICKET:  [Bug lỗi hiển thị trên app trên điện thoại và Ipad](https://viindoo.com/web#id=54188&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form)

LỖI HIỆN TẠI
![Screenshot 2024-10-02 at 10 27 21 AM](https://github.com/user-attachments/assets/ca143e39-e091-4ab4-b5b4-efc64f461e78)

KẾT QUẢ

![Screenshot 2024-10-02 at 10 27 04 AM](https://github.com/user-attachments/assets/c400cf88-f181-402b-bda2-346cba0d428c)

