### PR TITLE
[IMP] viin_brand_pos: add SALES RECEIPT label to pos receipt

### DIFF
--- a/viin_brand_pos/__manifest__.py
+++ b/viin_brand_pos/__manifest__.py
@@ -59,6 +59,7 @@ Module này sẽ thay đổi màu sắc của thanh điều hướng (navbar), c
             ('prepend', 'viin_brand_common/static/src/scss/primary_variables.scss'),
             ('prepend', 'viin_brand_common/static/src/legacy/scss/bootstrap_overridden_common.scss'),
             ('after', 'point_of_sale/static/src/scss/pos.scss', 'viin_brand_pos/static/src/scss/style.scss'),
+            'viin_brand_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml',
             'viin_brand_pos/static/src/xml/Chrome.xml',
             'viin_brand_pos/static/src/xml/CustomerFacingDisplayOrder.xml',
         ],

--- a/viin_brand_pos/i18n/vi_VN.po
+++ b/viin_brand_pos/i18n/vi_VN.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_pos
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-24 06:04+0000\n"
+"PO-Revision-Date: 2024-10-24 06:04+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: viin_brand_pos
+#. odoo-javascript
+#: code:addons/viin_brand_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml:0
+#, python-format
+msgid "SALES RECEIPT"
+msgstr "BIÊN LAI BÁN HÀNG"

--- a/viin_brand_pos/i18n/viin_brand_pos.pot
+++ b/viin_brand_pos/i18n/viin_brand_pos.pot
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_pos
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-24 06:03+0000\n"
+"PO-Revision-Date: 2024-10-24 06:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: viin_brand_pos
+#. odoo-javascript
+#: code:addons/viin_brand_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml:0
+#, python-format
+msgid "SALES RECEIPT"
+msgstr ""

--- a/viin_brand_pos/static/src/css/pos_receipts.css
+++ b/viin_brand_pos/static/src/css/pos_receipts.css
@@ -1,0 +1,5 @@
+.pos-receipt .pos-receipt-label {
+    text-align: center;
+    font-weight: 700;
+    font-size: 125%;
+}

--- a/viin_brand_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/viin_brand_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -1,0 +1,12 @@
+<templates id="template" xml:space="preserve">
+
+    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('orderlines')]" position="before">
+            <div class="pos-receipt-label">
+                SALES RECEIPT
+            </div>
+            <br /><br />
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
https://viindoo.com/web#id=54408&cids=1&menu_id=777&action=1074&active_id=50&model=viin.helpdesk.ticket&view_type=form
TODOs:

- [x] Align TOTAL and CHANGE labels on POS receipts to the start (PR for Odoo `https://github.com/odoo/odoo/pull/185014`)
- [x] add SALES RECEIPT label to pos receipt

Trước
![image](https://github.com/user-attachments/assets/a520afb0-2196-4127-86be-df6bb1e3b58c)

Sau
![Screenshot from 2024-10-24 13-09-42](https://github.com/user-attachments/assets/c1673bcf-7d60-4041-917d-4af10cc4da5e)
