### PR TITLE
[16.0][FIX] web_responsive: fix bad UI on crm team form view

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -167,7 +167,6 @@ html .o_web_client .o_action_manager .o_action {
         // Support for long title (with ellipsis)
         .oe_title {
             .o_field_widget:not(.oe_inline) {
-                display: block;
                 span:not(.o_field_translate) {
                     display: block;
                     max-width: 100%;


### PR DESCRIPTION
[[BUG] to_sales_team_advanced-Đội bán hàng hiển thị bad UI](https://viindoo.com/web#id=51045&cids=1&menu_id=289&action=1076&active_id=95332&model=viin.helpdesk.ticket&view_type=form)
---

For this PR:
---

- Sửa lỗi Bad UI Trên Sales Team

**Nguyên nhân**
- Với code gốc, OCA đang sử dụng giải pháp cho tiêu đề xuống dòng nếu quá dài. và nếu nó không được dịch thì sẽ bổ sung ... phía sau nó ( nếu nằm trong thẻ span )
- Tại CRM team, Odoo đang sử dụng class o_row mà không phải inline, nên vẫn bị dính thuộc tính display_block trong đoạn CSS của OCA, dẫn đến lỗi BAD UI như hình
![image](https://github.com/user-attachments/assets/9776e3b5-a9fe-4811-955c-ea8e5dacc40f)


**Giải pháp**
- Tạm thời bỏ thuộc tính `display_block` đi, vì chưa thấy nó có hiệu quả trong trường hợp thực tế ( đã kiểm thử ). Ví dụ tiêu đề dự án, sổ nhật ký.. đều có thuộc tính oe_inline nhưng vẫn không xuống dòng dù tiêu đề quá dài

![image](https://github.com/user-attachments/assets/939f2ed4-cd2f-488a-abdf-2fda9f22f549)
