### PR TITLE
[UPG + ADD][17.0] viin_brand_mail_bot*: debranding mail bot at version 17.0

### DIFF
--- a/viin_brand_im_livechat_mail_bot/__init__.py
+++ b/viin_brand_im_livechat_mail_bot/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/viin_brand_im_livechat_mail_bot/__manifest__.py
+++ b/viin_brand_im_livechat_mail_bot/__manifest__.py
@@ -1,0 +1,51 @@
+{
+    'name': "Im Live Chat Mail Bot Debranding for Viindoo",
+    'name_vi_VN': "Giao diện Viindoo cho module Tôi là Chat Bot Trực tuyến",
+
+    'summary': """
+Debranding Im Live Chat Mail Bot for Viindoo
+    """,
+    'summary_vi_VN': """
+Giao diện brand Viindoo cho module Tôi là Chat Bot Trực tuyến
+    """,
+
+    'description': """
+What it does
+============
+This module will change brand in Im Live Chat Mail Bot following Viindoo's brand
+
+Editions Supported
+==================
+1. Community Edition
+2. Enterprise Edition
+
+    """,
+
+    'description_vi_VN': """
+Ứng dụng này làm gì
+===================
+Module này sẽ thay đổi giao diện module Tôi là Chat Bot Trực tuyến theo thương hiệu Viindoo
+
+Ấn bản được Hỗ trợ
+==================
+1. Ấn bản Community
+2. Ấn bản Enterprise
+
+    """,
+
+    'author': "Viindoo",
+    'website': "https://viindoo.com",
+    'live_test_url': "https://v16demo-int.viindoo.com",
+    'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
+    'support': "apps.support@viindoo.com",
+    'category': 'Hidden',
+    'version': '0.1.0',
+
+    # any module necessary for this one to work correctly
+    'depends': ['im_livechat_mail_bot', 'viin_brand_common'],
+    'installable': True,
+    'auto_install': True,
+    'price': 0.0,
+    'currency': 'EUR',
+    'license': 'OPL-1',
+}

--- a/viin_brand_im_livechat_mail_bot/i18n/vi_VN.po
+++ b/viin_brand_im_livechat_mail_bot/i18n/vi_VN.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_im_livechat_mail_bot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-09 04:32+0000\n"
+"PO-Revision-Date: 2024-07-09 04:32+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: viin_brand_im_livechat_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_im_livechat_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+"Tuyệt vời, bạn có thể tùy chỉnh câu trả lời mẫu trong ứng dụng trò chuyện "
+"trực tiếp.<br/><br/><b>Đó là cuối cùng của bài viết này</b>, bạn có thể "
+"<b>đóng cuộc trò chuyện</b> hoặc bắt đầu hướng dẫn lại bằng cách gõ <span "
+"class=\"o_odoobot_command\">start the tour</span>. Chúc bạn khám phá Viindoo!"
+
+#. module: viin_brand_im_livechat_mail_bot
+#: model:ir.model,name:viin_brand_im_livechat_mail_bot.model_mail_bot
+msgid "Mail Bot"
+msgstr ""

--- a/viin_brand_im_livechat_mail_bot/i18n/viin_brand_im_livechat_mail_bot.pot
+++ b/viin_brand_im_livechat_mail_bot/i18n/viin_brand_im_livechat_mail_bot.pot
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_im_livechat_mail_bot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-09 04:31+0000\n"
+"PO-Revision-Date: 2024-07-09 04:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: viin_brand_im_livechat_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_im_livechat_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+
+#. module: viin_brand_im_livechat_mail_bot
+#: model:ir.model,name:viin_brand_im_livechat_mail_bot.model_mail_bot
+msgid "Mail Bot"
+msgstr ""

--- a/viin_brand_im_livechat_mail_bot/models/__init__.py
+++ b/viin_brand_im_livechat_mail_bot/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_bot

--- a/viin_brand_im_livechat_mail_bot/models/mail_bot.py
+++ b/viin_brand_im_livechat_mail_bot/models/mail_bot.py
@@ -1,0 +1,23 @@
+import threading
+from markupsafe import Markup
+
+from odoo import models, _
+
+
+class MailBot(models.AbstractModel):
+    _inherit = 'mail.bot'
+
+    def _get_answer(self, record, body, values, command):
+        test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
+        if test_mode:
+            return super(MailBot, self)._get_answer(record, body, values, command)
+        else:
+            odoobot_state = self.env.user.odoobot_state
+            if self._is_bot_in_private_channel(record):
+                # help message
+                if odoobot_state == "onboarding_canned" and self.env.context.get("canned_response_ids"):
+                    self.env.user.odoobot_failed = False
+                    self.env.user.odoobot_state = "idle"
+                    return Markup(_("Good, you can customize canned responses in the live chat application.<br/><br/><b>It's the end of this overview</b>, you can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+
+            return super(MailBot, self)._get_answer(record, body, values, command)

--- a/viin_brand_mail_bot/__manifest__.py
+++ b/viin_brand_mail_bot/__manifest__.py
@@ -43,7 +43,8 @@ Module này sẽ thay đổi giao diện module Mail Bot theo thương hiệu Vi
 
     # any module necessary for this one to work correctly
     'depends': ['mail_bot', 'viin_brand_common'],
-    'installable': False, # set auto_install True after upgrading for v17 after upgrading for v17
+    'installable': True,
+    'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',

--- a/viin_brand_mail_bot/i18n/vi_VN.po
+++ b/viin_brand_mail_bot/i18n/vi_VN.po
@@ -4,16 +4,50 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-13 10:42+0000\n"
-"PO-Revision-Date: 2023-02-13 10:42+0000\n"
+"POT-Creation-Date: 2024-07-09 04:29+0000\n"
+"PO-Revision-Date: 2024-07-09 04:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+"Rất tốt, bạn có thể tùy chỉnh các câu trả lời mẫu trong ứng dụng trò chuyện "
+"trực tiếp.<br/><br/><b>Đây là cuối cùng của bản tổng quan này</b>, bạn có thể"
+" <b>đóng cuộc trò chuyện này</b> hoặc bắt đầu chuyến tham quan lại bằng cách "
+"nhập <span class=\"o_odoobot_command\">start the tour</span>. Hãy thưởng thức "
+"việc khám phá Viindoo!"
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"I am a simple bot, but if that's a dog, he is the cutest 😊 "
+"<br/>Congratulations, you finished this tour. You can now <b>close this "
+"conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+"Tôi chỉ là một robot đơn giản, nhưng nếu đó là một con chó, nó là con chó dễ"
+" thương nhất 😊 <br/>Chúc mừng bạn đã hoàn thành chuyến tham quan này. Bạn có"
+" thể <b>đóng cuộc trò chuyện này</b> hoặc bắt đầu chuyến tham quan lại bằng "
+"cách nhập <span class=\"o_odoobot_command\">start the tour</span>. Hãy "
+"thưởng thức việc khám phá Viindoo!"
 
 #. module: viin_brand_mail_bot
 #: model:ir.model,name:viin_brand_mail_bot.model_mail_bot

--- a/viin_brand_mail_bot/i18n/vi_VN.po
+++ b/viin_brand_mail_bot/i18n/vi_VN.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-09 04:29+0000\n"
-"PO-Revision-Date: 2024-07-09 04:29+0000\n"
+"POT-Creation-Date: 2025-07-02 02:11+0000\n"
+"PO-Revision-Date: 2025-07-02 02:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,10 +27,10 @@ msgid ""
 "Viindoo!"
 msgstr ""
 "Rất tốt, bạn có thể tùy chỉnh các câu trả lời mẫu trong ứng dụng trò chuyện "
-"trực tiếp.<br/><br/><b>Đây là cuối cùng của bản tổng quan này</b>, bạn có thể"
-" <b>đóng cuộc trò chuyện này</b> hoặc bắt đầu chuyến tham quan lại bằng cách "
-"nhập <span class=\"o_odoobot_command\">start the tour</span>. Hãy thưởng thức "
-"việc khám phá Viindoo!"
+"trực tiếp.<br/><br/><b>Đây là cuối cùng của bản tổng quan này</b>, bạn có "
+"thể <b>đóng cuộc trò chuyện này</b> hoặc bắt đầu chuyến tham quan lại bằng "
+"cách nhập <span class=\"o_odoobot_command\">start the tour</span>. Hãy "
+"thưởng thức việc khám phá Viindoo!"
 
 #. module: viin_brand_mail_bot
 #. odoo-python
@@ -59,6 +59,17 @@ msgstr ""
 #: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
 #, python-format
 msgid ""
+"Sorry, I am not listening. To get someone's attention, <b>ping him</b>. "
+"Write <span class=\"o_odoobot_command\">@ViindooBot</span> and select me."
+msgstr ""
+"Xin lỗi, tôi không nghe thấy. Để thu hút sự chú ý của ai đó, <b>hãy ping họ</b>. "
+"Viết <span class=\"o_odoobot_command\">@ViindooBot</span> và chọn tôi."
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
 "Unfortunately, I'm just a bot 😞 I don't understand! If you need help "
 "discovering our product, please check <a "
 "href=\"https://www.viindoo.com/documentation\" target=\"_blank\">our "
@@ -70,3 +81,16 @@ msgstr ""
 "href=\"https://viindoo.com/documentation\" target=\"_blank\">tài liệu của "
 "chúng tôi</a> hoặc các <a href=\"https://viindoo.com/slides\" "
 "target=\"_blank\">video của chúng tôi</a>."
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Wow you are a natural!<br/>Ping someone with @username to grab their "
+"attention. <b>Try to ping me using</b> <span "
+"class=\"o_odoobot_command\">@ViindooBot</span> in a sentence."
+msgstr ""
+"Wow bạn thật tự nhiên!<br/>Ping ai đó với @username để thu hút sự chú ý của họ. "
+"<b>Hãy thử ping tôi bằng cách sử dụng</b> <span "
+"class=\"o_odoobot_command\">@ViindooBot</span> trong một câu."

--- a/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
+++ b/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
@@ -4,16 +4,40 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-13 10:42+0000\n"
-"PO-Revision-Date: 2023-02-13 10:42+0000\n"
+"POT-Creation-Date: 2024-07-09 04:29+0000\n"
+"PO-Revision-Date: 2024-07-09 04:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Good, you can customize canned responses in the live chat "
+"application.<br/><br/><b>It's the end of this overview</b>, you can now "
+"<b>close this conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"I am a simple bot, but if that's a dog, he is the cutest 😊 "
+"<br/>Congratulations, you finished this tour. You can now <b>close this "
+"conversation</b> or start the tour again with typing <span "
+"class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering "
+"Viindoo!"
+msgstr ""
 
 #. module: viin_brand_mail_bot
 #: model:ir.model,name:viin_brand_mail_bot.model_mail_bot

--- a/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
+++ b/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-09 04:29+0000\n"
-"PO-Revision-Date: 2024-07-09 04:29+0000\n"
+"POT-Creation-Date: 2025-07-02 02:11+0000\n"
+"PO-Revision-Date: 2025-07-02 02:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -49,9 +49,28 @@ msgstr ""
 #: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
 #, python-format
 msgid ""
+"Sorry, I am not listening. To get someone's attention, <b>ping him</b>. "
+"Write <span class=\"o_odoobot_command\">@ViindooBot</span> and select me."
+msgstr ""
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
 "Unfortunately, I'm just a bot 😞 I don't understand! If you need help "
 "discovering our product, please check <a "
 "href=\"https://www.viindoo.com/documentation\" target=\"_blank\">our "
 "documentation</a> or <a href=\"https://www.viindoo.com/slides\" "
 "target=\"_blank\">our videos</a>."
+msgstr ""
+
+#. module: viin_brand_mail_bot
+#. odoo-python
+#: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
+#, python-format
+msgid ""
+"Wow you are a natural!<br/>Ping someone with @username to grab their "
+"attention. <b>Try to ping me using</b> <span "
+"class=\"o_odoobot_command\">@ViindooBot</span> in a sentence."
 msgstr ""

--- a/viin_brand_mail_bot/models/mail_bot.py
+++ b/viin_brand_mail_bot/models/mail_bot.py
@@ -1,4 +1,5 @@
 import threading
+from markupsafe import Markup
 
 from odoo import models, _
 
@@ -8,15 +9,24 @@ class MailBot(models.AbstractModel):
 
     def _get_answer(self, record, body, values, command=False):
         test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
-        res = super(MailBot, self)._get_answer(record, body, values, command)
         if test_mode:
-            return res
+            return super(MailBot, self)._get_answer(record, body, values, command)
         else:
             odoobot_state = self.env.user.odoobot_state
             if self._is_bot_in_private_channel(record):
                 # help message
                 if self._is_help_requested(body) or odoobot_state == 'idle':
-                    return _("Unfortunately, I'm just a bot 😞 I don't understand! If you need help discovering our product, please check "
+                    return Markup(_("Unfortunately, I'm just a bot 😞 I don't understand! If you need help discovering our product, please check "
                              "<a href=\"https://www.viindoo.com/documentation\" target=\"_blank\">our documentation</a> or "
-                             "<a href=\"https://www.viindoo.com/slides\" target=\"_blank\">our videos</a>.")
-                return res
+                             "<a href=\"https://www.viindoo.com/slides\" target=\"_blank\">our videos</a>."))
+                elif odoobot_state == 'onboarding_attachement' and values.get("attachment_ids"):
+                    self.env.user.odoobot_state = "idle"
+                    self.env.user.odoobot_failed = False
+                    return Markup(_("I am a simple bot, but if that's a dog, he is the cutest 😊 <br/>Congratulations, you finished this tour. You can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+                # Actually this one should be in im_livechat_mail_bot
+                elif odoobot_state == "onboarding_canned" and self.env.context.get("canned_response_ids"):
+                    self.env.user.odoobot_failed = False
+                    self.env.user.odoobot_state = "idle"
+                    return Markup(_("Good, you can customize canned responses in the live chat application.<br/><br/><b>It's the end of this overview</b>, you can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+
+            return super(MailBot, self)._get_answer(record, body, values, command)

--- a/viin_brand_mail_bot/models/mail_bot.py
+++ b/viin_brand_mail_bot/models/mail_bot.py
@@ -14,8 +14,12 @@ class MailBot(models.AbstractModel):
         else:
             odoobot_state = self.env.user.odoobot_state
             if self._is_bot_in_private_channel(record):
+                if odoobot_state == 'onboarding_command' and command == 'help':
+                    self.env.user.odoobot_state = "onboarding_ping"
+                    self.env.user.odoobot_failed = False
+                    return Markup(_("Wow you are a natural!<br/>Ping someone with @username to grab their attention. <b>Try to ping me using</b> <span class=\"o_odoobot_command\">@ViindooBot</span> in a sentence."))
                 # help message
-                if self._is_help_requested(body) or odoobot_state == 'idle':
+                elif self._is_help_requested(body) or odoobot_state == 'idle':
                     return Markup(_("Unfortunately, I'm just a bot 😞 I don't understand! If you need help discovering our product, please check "
                              "<a href=\"https://www.viindoo.com/documentation\" target=\"_blank\">our documentation</a> or "
                              "<a href=\"https://www.viindoo.com/slides\" target=\"_blank\">our videos</a>."))
@@ -28,5 +32,8 @@ class MailBot(models.AbstractModel):
                     self.env.user.odoobot_failed = False
                     self.env.user.odoobot_state = "idle"
                     return Markup(_("Good, you can customize canned responses in the live chat application.<br/><br/><b>It's the end of this overview</b>, you can now <b>close this conversation</b> or start the tour again with typing <span class=\"o_odoobot_command\">start the tour</span>. Enjoy discovering Viindoo!"))
+                elif odoobot_state == 'onboarding_ping' and not self._is_bot_pinged(values):
+                    self.env.user.odoobot_failed = True
+                    return Markup(_("Sorry, I am not listening. To get someone's attention, <b>ping him</b>. Write <span class=\"o_odoobot_command\">@ViindooBot</span> and select me."))
 
             return super(MailBot, self)._get_answer(record, body, values, command)


### PR DESCRIPTION
Được tách ra từ
---
- https://github.com/Viindoo/branding/pull/483

Task
---

- [viin_brand_mail_bot](https://viindoo.com/web#id=91589&cids=1&menu_id=289&action=409&active_id=392&model=project.task&view_type=form)

PR này để:
----

Nâng cấp mô đun `viin_brand_mail_bot` lên phiên bản 17.0 và bổ sung thêm mô đun `viin_brand_im_livechat_mail_bot` phục vụ cho việc debranding mô đun `im_livechat_mail_bot` của odoo