### PR TITLE
[IMP][17.0] web_responsive: improve visual and add sticky to header

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -102,6 +102,30 @@ $chatter_zone_width: 35% !important;
             }
         }
 
+        .o_form_statusbar {
+            position: sticky !important;
+            top: 0;
+            z-index: 2;
+            border-top: 0.5px solid #dee2e6;
+            border-bottom: 0.5px solid #dee2e6;
+            padding-bottom: 0px !important;
+            background: white;
+        }
+
+        .o_form_sheet_bg {
+            padding-top: 0;
+            padding-left: 0;
+            padding-right: 0;
+            border-right: 1px solid #dee2e6;
+        }
+
+        .o_statusbar_buttons {
+            padding-left: 16px;
+        }
+
+        .o_form_sheet {
+            margin: 8px 32px
+        }
         @include media-breakpoint-down(sm) {
             min-width: auto;
 


### PR DESCRIPTION
### PR NÀY ĐỂ:
- Sửa một số css cho header gần giống bản 16 và thêm sticky header

Reference of the [issue/task](https://viindoo.com/web?debug=0#id=54037&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form) this PR addresses:

Current behavior before PR:

[Screencast from 16-06-2025 09:43:13.webm](https://github.com/user-attachments/assets/b43abd3b-f577-4cf0-88f8-1cc90b62b52f)



Desired behavior after PR is merged:

![Screenshot from 2025-06-16 09-45-21](https://github.com/user-attachments/assets/5c4e40f8-8897-4d5e-a07a-f3343caaaed1)


[Screencast from 16-06-2025 09:44:15.webm](https://github.com/user-attachments/assets/0cf16952-e7cc-4f51-bc4e-268517c53f47)



-- 
I confirm I have read guidelines at https://github.com/Viindoo/viindoo-technical-rules/blob/main/technical-rules.rst and check all the following conventions:

- [x] Convention about Viindoo Coding: https://github.com/Viindoo/viindoo-technical-rules/blob/main/technical-rules.rst#viindoo-coding
- [x] Convention about Commit Message: https://github.com/Viindoo/viindoo-technical-rules/blob/main/technical-rules.rst#commit-message
- [x] Convention about Stable Policy: https://github.com/Viindoo/viindoo-technical-rules/blob/main/technical-rules.rst#stable-policy
- [x] Convention about Pull Request: https://github.com/Viindoo/viindoo-technical-rules/blob/main/technical-rules.rst#pull-request