### PR TITLE
[WIP][16.0][ADD] viin_brand_zalo: responsibe zalo button

### DIFF
--- a/viin_brand_zalo/__manifest__.py
+++ b/viin_brand_zalo/__manifest__.py
@@ -1,0 +1,66 @@
+{
+    'name': "Zalo Branding For Viindoo",
+    'name_vi_VN': "Giao diện Viindoo cho module Zalo ",
+
+    'summary': """
+Theme branding Viindoo for module Zalo""",
+    'summary_vi_VN': """
+Giao diện brand Viindoo cho module Zalo
+""",
+
+    'description': """
+Problem
+=======
+- On version 16.0, the Web Responsive module overwrites the entire structure of the `mail.ChatterTopbar` template, leading to some xpath that cannot be performed, because if there is xpath, it will be replaced by the entire.
+- For example, in the `Zalo` module, there is an xpath to the element `div hassclass o_ChatterTopbar_controllers` but when the Web Responsive module replaces the entire, it will not be able to find the element.
+
+Solution
+========
+- To solve this problem, we will create a new module `viin_brand_zalo` to inherit the `mail.ChatterTopbar` template after being replaced by Web Responsive.
+
+Editions Supported
+==================
+1. Community Edition
+2. Enterprise Edition
+
+    """,
+
+    'description_vi_VN': """
+Vấn đề
+======
+- Trên phiên bản 16.0, mô đun Web Responsive thực hiện ghi đè lại toàn bộ cấu trúc của template `mail.ChatterTopbar` dẫn đến một số xpath không thể thực hiện, do có xpath rồi thì vẫn bị replace đi toàn bộ.
+- Ví dụ điển hình là tại mô đun `Zalo` có thực hiện xpath tới element `div hassclass o_ChatterTopbar_controllers` nhưng khi bị mô đun Web Responsive replace toàn bộ
+
+Giải pháp
+=========
+- Để giải quyết vấn đề này, chúng tôi sẽ tạo một mô đun mới `viin_brand_zalo` để thực hiện kế thừa lại template `mail.ChatterTopbar` sau khi bị Web Responsive replace.
+
+Ấn bản được Hỗ trợ
+==================
+1. Ấn bản Community
+2. Ấn bản Enterprise
+
+""",
+
+    'author': "Viindoo",
+    'website': "https://viindoo.com",
+    'live_test_url': "https://v16demo-int.viindoo.com",
+    'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
+    'support': "apps.support@viindoo.com",
+
+    'category': 'Hidden',
+    'version': '0.1',
+    'depends': ['viin_zalo', 'web_responsive'],
+
+    'assets': {
+        'web.assets_backend': [
+            'viin_brand_zalo/static/src/components/chatter_topbar/*.xml',
+        ],
+    },
+    'installable': True,  # todo: remove me in version 17.0 because web responsive not replace the entire template
+    'application': False,
+    'auto_install': True,
+    'price': 0.0,
+    'currency': 'EUR',
+    'license': 'OPL-1',
+}

--- a/viin_brand_zalo/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/viin_brand_zalo/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+	<t t-inherit="mail.ChatterTopbar" t-inherit-mode="extension" owl="1">
+		<xpath expr="//button[hasclass('o_ChatterTopbar_buttonLogNote')]" position="before">
+			<button class="o_ChatterTopbar_button o_ChatterTopbar_buttonZalo btn text-nowrap"
+				type="button"
+				t-att-class="{
+					'o-active btn-odoo': chatterTopbar.chatter.composerView and !chatterTopbar.chatter.composerView.composer.isLog,
+					'btn-odoo': !chatterTopbar.chatter.composerView,
+					'btn-light': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
+				}"
+				t-att-disabled="!chatterTopbar.chatter.canPostMessage"
+				data-hotkey="m"
+				t-on-click="chatterTopbar.chatter.onClickZalo"
+			>
+				<img src="/viin_zalo/static/src/img/zalo_icon.png" width="16" height="16" class="me-1"/>
+				Zalo
+			</button>
+		</xpath>
+	</t>
+</templates>


### PR DESCRIPTION
Depend On:
---

- https://github.com/Viindoo/tvtmaaddons/pull/13082
- https://github.com/Viindoo/tvtmaaddons/pull/12152

PR này để:
---

- Giải quyết bài toán mô đun `web_responsive` ghi đè replace toàn bộ khối `o_ChatterTopbar` tại [đây](https://github.com/Viindoo/branding/blob/2c886ffd21bdbdc63f06cdd515db26fc684efcea/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml#L14) dẫn đến tất cả thực hiện xpath bên trong khối này trở nên vô dụng
- 
```html
        t-name="web.Responsivemail.ChatterTopbar"
        t-inherit="mail.ChatterTopbar"
        owl="1"
        t-inherit-mode="extension"
    >
        <xpath expr="//div[contains(@class, 'o_ChatterTopbar')]" position="replace">
``` 
- Sẽ xóa mô đun này ở phiên bản 17.0 do Oca không còn thực hiện replace nữa
