### PR TITLE
[FIX][16.0] web_responsive: fix show scroll in text input

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -49,6 +49,7 @@
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.xml",
             "/web_responsive/static/src/views/form/form_controller.scss",
             "/web_responsive/static/src/components/message/message.xml",
+            "/web_responsive/static/src/components/composer/text_input.scss",
         ],
         "web.assets_tests": [
             "/web_responsive/static/tests/test_patch.js",

--- a/web_responsive/static/src/components/composer/text_input.scss
+++ b/web_responsive/static/src/components/composer/text_input.scss
@@ -1,0 +1,3 @@
+.o_ComposerTextInput_textareaStyle{
+	min-height: 43px !important;
+}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
---
[[BUG]: box chat bad ui](https://viindoo.com/web#id=58100&menu_id=89&cids=1&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Sửa lại phần chat bị hiện thanh scroll dọc mặc dù chưa có text bằng cách tăng chiều cao

LÝ DO:
---
- font-size của Viindoo lớn hơn Odoo khiến cho padding và line-height(tính theo font default là 1.5) cộng vào vượt quá size của container nên bị hiện scroll
-  Điều này còn tùy vào trình duyệt bởi vì size của container là dựa vào scrollHeight của trình duyệt trả ra do đó giá trị sẽ khác nhau nên ở đây em sẽ fix cứng giá trị là 44px để container luôn đủ độ rộng
![image](https://github.com/user-attachments/assets/12cc074b-52dd-46ab-9cdc-e3529e4601d8)

VD:  padding-top: 10px, paddding-bottom:10px sẽ cộng với line height để ra tổng độ rộng cần
- Viindoo: font-size: 15px = > line height: 1.5 = 22.5px tổng bằng 42.5px mà container chỉ có 40px nên bị hiện scroll.
![image](https://github.com/user-attachments/assets/03eb3131-9c5e-478d-8319-0a9f80ed8938)

- Odoo: font-size: 12px => line-height 1.5 = 19.5px bằng 39.5px vừa với container 40px
![image](https://github.com/user-attachments/assets/5d0a4fcd-2dc8-436b-9c6c-ace09dc18b29)

Current behavior before PR:

![image](https://github.com/user-attachments/assets/27bf7c32-1b2a-485e-8455-9a0045e1039e)


Desired behavior after PR is merged:

![image](https://github.com/user-attachments/assets/239d62b7-9e8f-45cf-abc0-8036c7416ee8)

