### PR TITLE
[FIX][17.0] web_response: fix text input container size

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -35,7 +35,6 @@
             "/web_responsive/static/src/legacy/scss/list_sticky_header.scss",
             "/web_responsive/static/src/legacy/js/web_responsive.esm.js",
             "/web_responsive/static/src/legacy/xml/form_buttons.xml",
-<<<<<<< HEAD
             "/web_responsive/static/src/legacy/xml/custom_favorite_item.xml",
             "/web_responsive/static/src/components/apps_menu_tools.esm.js",
             "/web_responsive/static/src/components/apps_menu/*",
@@ -52,20 +51,6 @@
             "/web_responsive/static/src/components/control_panel/*",
             "/web_responsive/static/src/components/command_palette/*",
             "/web_responsive/static/src/views/form/*",
-=======
-            "/web_responsive/static/src/components/apps_menu/apps_menu.xml",
-            "/web_responsive/static/src/components/control_panel/control_panel.xml",
-            "/web_responsive/static/src/components/search_panel/search_panel.xml",
-            "/web_responsive/static/src/components/hotkey/hotkey.xml",
-            "/web_responsive/static/src/components/chatter_topbar/chatter_topbar.esm.js",
-            "/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml",
-            "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss",
-            "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.esm.js",
-            "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.xml",
-            "/web_responsive/static/src/views/form/form_controller.scss",
-            "/web_responsive/static/src/components/message/message.xml",
-            "/web_responsive/static/src/components/composer/text_input.scss",
->>>>>>> b538367 ([FIX] web_responsive: fix show scroll in text input)
         ],
         "web.assets_tests": [
             "/web_responsive/static/tests/test_patch.js",

--- a/web_responsive/static/src/components/composer/text_input.scss
+++ b/web_responsive/static/src/components/composer/text_input.scss
@@ -1,3 +1,0 @@
-.o_ComposerTextInput_textareaStyle{
-	min-height: 43px !important;
-}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
---
[[BUG]: box chat bad ui](https://viindoo.com/web#id=58100&menu_id=89&cids=1&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Sửa Fwd lên bản 17

LÝ DO:
---
- do odoo đã có người sửa nên e xóa phần này đi, sau này khi cập nhật code odoo phần này sẽ tự sửa
[[FIX] mail: composer correct height when empty](https://github.com/odoo/odoo/pull/216742)
![image](https://github.com/user-attachments/assets/53c129b2-46a4-4ad7-8e59-098e266490ae)
