### PR TITLE
[UPG][18.0] viin_brand_auth_totp: xpath reallocated

### DIFF
--- a/viin_brand_auth_totp/__manifest__.py
+++ b/viin_brand_auth_totp/__manifest__.py
@@ -36,8 +36,8 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication theo t
 
     'author': "Viindoo",
     'website': "https://viindoo.com",
-    'live_test_url': "https://v16demo-int.viindoo.com",
-    'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
+    'live_test_url': "https://v18demo-int.viindoo.com",
+    'live_test_url_vi_VN': "https://v18demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",
 
     # Categories can be used to filter modules in modules listing
@@ -54,7 +54,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication theo t
         'views/user_perferences.xml',
         'views/templates.xml',
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',

--- a/viin_brand_auth_totp/views/user_perferences.xml
+++ b/viin_brand_auth_totp/views/user_perferences.xml
@@ -5,8 +5,8 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="auth_totp.view_totp_field" />
         <field name="arch" type="xml">
-            <xpath expr="//div/span/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/16.0/applications/getting-started/external-apps-integration/two-factor-authentication.html</attribute>
+            <xpath expr="//div/span/widget" position="attributes">
+                <attribute name="path">https://viindoo.com/documentation/16.0/applications/getting-started/external-apps-integration/two-factor-authentication.html</attribute>
             </xpath>
         </field>
     </record>
@@ -16,8 +16,8 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="auth_totp.view_totp_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='security']/div/span/a" position="attributes">
-                <attribute name="href">https://viindoo.com/documentation/16.0/applications/getting-started/external-apps-integration/two-factor-authentication.html</attribute>
+            <xpath expr="//div/span/widget" position="attributes">
+                <attribute name="path">https://viindoo.com/documentation/16.0/applications/getting-started/external-apps-integration/two-factor-authentication.html</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
PR NÀY ĐỂ:
---
- Nâng cấp module lên 18
- Sửa lại phần xpath do bây odoo sử dụng widget document link thay vì thẻ a

GIẢI PHÁP:
---
- Thay path của widget bằng link viindoo

[Screencast from 10-09-2025 16:06:18.webm](https://github.com/user-attachments/assets/1d807525-c63a-4b02-affd-19f62184b4ae)
