### PR TITLE
[UPG][18.0] viin_brand_base_import: remove unused views and change inherit

### DIFF
--- a/viin_brand_base_import/__manifest__.py
+++ b/viin_brand_base_import/__manifest__.py
@@ -36,8 +36,8 @@ Module này sẽ thay đổi giao diện module Base import theo thương hiệu
 
     'author': "Viindoo",
     'website': "https://viindoo.com",
-    'live_test_url': "https://v16demo-int.viindoo.com",
-    'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
+    'live_test_url': "https://v18demo-int.viindoo.com",
+    'live_test_url_vi_VN': "https://v18demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",
 
     # Categories can be used to filter modules in modules listing
@@ -52,12 +52,10 @@ Module này sẽ thay đổi giao diện module Base import theo thương hiệu
     # always loaded
     'assets': {
         'web.assets_backend': [
-            'viin_brand_base_import/static/src/import_action/import_action.xml',
             'viin_brand_base_import/static/src/import_data_content/import_data_content.xml',
-            'viin_brand_base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml',
             ]
     },
-    'installable': False,
+    'installable': True,
     'auto_install': True,
     'price': 0.0,
     'currency': 'EUR',

--- a/viin_brand_base_import/static/src/import_action/import_action.xml
+++ b/viin_brand_base_import/static/src/import_action/import_action.xml
@@ -1,7 +1,0 @@
-<templates xml:space="preserve">
-    <t t-inherit="base_import.ImportAction" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o_nocontent_help')]/a" position="attributes">
-            <attribute name="href">https://viindoo.com/documentation/16.0/applications/getting-started/guiding-to-import-and-export-data.html#import-data-into-viindoo-software</attribute>
-        </xpath>
-    </t>
-</templates>

--- a/viin_brand_base_import/static/src/import_data_content/import_data_content.xml
+++ b/viin_brand_base_import/static/src/import_data_content/import_data_content.xml
@@ -1,5 +1,5 @@
 <templates xml:space="preserve">
-    <t t-inherit="base_import.ImportDataContent" t-inherit-mode="extension">
+    <t t-inherit="ImportDataContent" t-inherit-mode="extension">
         <xpath expr="//p[hasclass('alert-info')]" position="replace" mode="inner">
             If the file contains
             the column names, the System can try auto-detecting the

--- a/viin_brand_base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/viin_brand_base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -1,7 +1,0 @@
-<templates xml:space="preserve">
-    <t t-inherit="base_import.ImportDataSidepanel" t-inherit-mode="extension">
-        <xpath expr="//a[./i[hasclass('fa-external-link')]]" position="attributes">
-            <attribute name="href">https://viindoo.com/documentation/16.0/applications/getting-started/guiding-to-import-and-export-data.html#import-data-into-viindoo-software</attribute>
-        </xpath>
-    </t>
-</templates>


### PR DESCRIPTION
PR NÀY ĐỂ:
---
- Nâng cấp lên 18
- xóa một số views xpath do bây giờ odoo dùng thẻ <DocumentationLink> thay vì <a> 
- Odoo sửa lại cách inherit của templates: t-inherit = t-name thay vì cần my_module.views

REF:
https://github.com/odoo/odoo/commit/43e1342c69be07bfb8a95df1ae3d7029427ede40

<img width="1915" height="1079" alt="image" src="https://github.com/user-attachments/assets/3cf8f1ba-8e17-4654-a165-fe11d972ae0d" />
