### PR TITLE
[MISC][18.0] viin_brand_website_forum:  add viindoo logo and texts

### DIFF
--- a/viin_brand_website/views/website_templates.xml
+++ b/viin_brand_website/views/website_templates.xml
@@ -15,8 +15,12 @@
     </template>
     
     <template id="layout" name="Main layout" inherit_id="website.layout">
-    	<xpath expr="//meta[@name='generator']" position="attributes">
-    		<attribute name="content">Viindoo</attribute>
-    	</xpath>
+		<xpath expr="//meta[@name='generator']" position="attributes">
+			<attribute name="content">Viindoo</attribute>
+		</xpath>
+
+        <xpath expr="//t[@t-set='x_icon']" position="replace">
+            <t t-set="x_icon" t-value="'/viin_brand/static/img/favicon.ico'"/>
+        </xpath>
     </template>
 </odoo>

--- a/viin_brand_website_forum/__init__.py
+++ b/viin_brand_website_forum/__init__.py
@@ -1,0 +1,4 @@
+def post_init_hook(env):
+    if env.ref('website_forum.forum_help', raise_if_not_found=False):
+        forum_help = env.ref('website_forum.forum_help')
+        forum_help._set_default_faq()

--- a/viin_brand_website_forum/i18n/vi_VN.po
+++ b/viin_brand_website_forum/i18n/vi_VN.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_website_forum
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-08 08:03+0000\n"
+"PO-Revision-Date: 2025-10-08 08:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "how to configure or customize Viindoo to specific business needs,"
+msgstr "Cách cấu hình hoặc tùy chỉnh Viindoo cho các nhu cầu kinh doanh cụ thể,"
+
+#. module: viin_brand_website_forum
+#: model_terms:ir.ui.view,arch_db:viin_brand_website_forum.viin_brand_website_forum_default_faq_inherit
+msgid "how to develop modules for your own need,"
+msgstr "Cách phát triển các mô-đun theo nhu cầu riêng của bạn,"
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "how to install Viindoo on a specific infrastructure,"
+msgstr "Cách cài đặt Viindoo trên một hạ tầng cụ thể,"
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "specific questions about Viindoo service offers, etc."
+msgstr "Các câu hỏi cụ thể về các gói dịch vụ của Viindoo, v.v."
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "what's the best way to use Viindoo for a specific business need,"
+msgstr "Cách tốt nhất để sử dụng Viindoo cho một nhu cầu kinh doanh cụ thể,"
+

--- a/viin_brand_website_forum/i18n/viin_brand_website_forum.pot
+++ b/viin_brand_website_forum/i18n/viin_brand_website_forum.pot
@@ -1,0 +1,41 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* viin_brand_website_forum
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-08 08:03+0000\n"
+"PO-Revision-Date: 2025-10-08 08:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "how to configure or customize Viindoo to specific business needs,"
+msgstr ""
+
+#. module: viin_brand_website_forum
+#: model_terms:ir.ui.view,arch_db:viin_brand_website_forum.viin_brand_website_forum_default_faq_inherit
+msgid "how to develop modules for your own need,"
+msgstr ""
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "how to install Viindoo on a specific infrastructure,"
+msgstr ""
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "specific questions about Viindoo service offers, etc."
+msgstr ""
+
+#. module: website_forum
+#: model_terms:forum.forum,faq:website_forum.forum_help
+msgid "what's the best way to use Viindoo for a specific business need,"
+msgstr ""

--- a/viin_brand_website_forum/views/forum_forum_template_faq.xml
+++ b/viin_brand_website_forum/views/forum_forum_template_faq.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <data>
+        <record id="viin_brand_website_forum_default_faq_inherit" model="ir.ui.view">
+            <field name="name">Faq Accordion (Viindoo)</field>
+            <field name="type">qweb</field>
+            <field name="inherit_id" ref="website_forum.default_faq"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@id='o_website_forum_faq_heading_1']/div[hasclass('accordion-body')]//ul" position="replace" mode="inner">
+                    <li>how to install Viindoo on a specific infrastructure,</li>
+                    <li>how to configure or customize Viindoo to specific business needs,</li>
+                    <li>what's the best way to use Viindoo for a specific business need,</li>
+                    <li>how to develop modules for your own need,</li>
+                    <li>specific questions about Viindoo service offers, etc.</li>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/viin_brand_website_slides_forum/__init__.py
+++ b/viin_brand_website_slides_forum/__init__.py
@@ -1,0 +1,8 @@
+def post_init_hook(env):
+    forums = env['forum.forum']
+    if env.ref('website_slides_forum.forum_forum_demo_channel_0', raise_if_not_found=False):
+        forums |= env.ref('website_slides_forum.forum_forum_demo_channel_0')
+    if env.ref('website_slides_forum.forum_forum_demo_channel_2', raise_if_not_found=False):
+        forums |= env.ref('website_slides_forum.forum_forum_demo_channel_2')
+    if forums:
+        forums._set_default_faq()

--- a/viin_brand_website_slides_forum/__manifest__.py
+++ b/viin_brand_website_slides_forum/__manifest__.py
@@ -1,17 +1,17 @@
 {
-    'name': "Forum Branding For Viindoo",
+    'name': "Slides Forum Branding For Viindoo",
     'name_vi_VN': "Giao diện Viindoo cho module Forum",
 
     'summary': """
-Theme branding Viindoo for module Events""",
+Theme branding Viindoo for module Slides Forum""",
     'summary_vi_VN': """
-Giao diện brand Viindoo cho module Events
+Giao diện brand Viindoo cho module Slides Forum
 """,
 
     'description': """
 What it does
 ============
-This module will change color in navigate bar, button and logo,v.v module Forum following Viindoo's brand
+This module will change color in navigate bar, button and logo,v.v module Slides Forum following Viindoo's brand
 
 
 Editions Supported
@@ -24,7 +24,7 @@ Editions Supported
     'description_vi_VN': """
 Ứng dụng này làm gì
 ===================
-Module này sẽ thay đổi giao diện module Forum theo thương hiệu Viindoo
+Module này sẽ thay đổi giao diện module Slides Forum theo thương hiệu Viindoo
 
 
 Ấn bản được Hỗ trợ
@@ -47,17 +47,11 @@ Module này sẽ thay đổi giao diện module Forum theo thương hiệu Viind
     'version': '0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['website_forum'],
-    'data': [
-        'views/forum_forum_template_faq.xml',
-    ],
+    'depends': ['website_slides_forum', 'viin_brand_website_forum'],
     # always loaded
-    'demo': [
-        'data/forum_demo.xml',
-    ],
     'post_init_hook': 'post_init_hook',
     'installable': True,
-    'auto_install': True,
+    'auto_install': ['website_slides_forum'],
     'price': 0.0,
     'currency': 'EUR',
     'license': 'OPL-1',


### PR DESCRIPTION
TICKET:
---
[[BUG][18.0] viin_brand_website_forum: Vẫn hiển thị logo và text Odoo](https://viindoo.com/web?debug=#id=59310&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Thêm logo viindoo và sửa các text odoo thành viindoo
- Thêm module viin_brand_website_slides_forum để sửa dữ liệu từ odoo thành viindoo cho module website_slides_forum

Hình ảnh:
---
<img width="1920" height="1076" alt="image" src="https://github.com/user-attachments/assets/a47b4caf-ef6c-450d-87e0-51d4228b4ba5" />
