### PR TITLE
[FIX][18.0] viin_brand_website_slides: fix bad UI

### DIFF
--- a/viin_brand_common/static/src/scss/bootstrap_review_frontend.scss
+++ b/viin_brand_common/static/src/scss/bootstrap_review_frontend.scss
@@ -4,3 +4,51 @@
 		color: $white;
 	}
 }
+
+.dropdown-item {
+	padding: 8px 14px;
+	transition: all 0.2s ease-in-out;
+}
+
+.form-control:focus {
+	outline: none;
+	border-color: $brand-primary !important;
+	box-shadow:
+		0 0 4px rgba($brand-primary, 0.4),
+		0 0 8px rgba($brand-primary, 0.3);
+	transition: all 0.25s ease;
+}
+
+.o_cc .dropdown-menu .dropdown-item.active,
+.navbar-light .o_dropdown_menu .dropdown-item:active {
+	--dropdown-link-active-color: #{$white} !important;
+}
+
+.dropdown-item.active,
+.dropdown-item:active {
+	background: $brand-primary !important;
+	color: white !important;
+}
+
+.form-check-input {
+	&:focus {
+		border-color: $brand-primary !important;
+		box-shadow: none;
+	}
+
+	&:checked {
+		background-color: $brand-primary !important;
+		border-color: $brand-primary !important;
+	}
+
+	&:hover {
+		border-color: $brand-primary !important;
+	}
+}
+
+.form-check,
+.form-switch {
+	&:hover .form-check-input:not(:disabled) {
+		border-color: $brand-primary !important;
+	}
+}

--- a/viin_brand_website_slides/__manifest__.py
+++ b/viin_brand_website_slides/__manifest__.py
@@ -40,6 +40,15 @@ Editions Supported
     # any module necessary for this one to work correctly
     'depends': ['website_slides'],
 
+    'assets': {
+        'web.assets_frontend': [
+            'viin_brand_website_slides/static/src/scss/website_slides.scss',
+        ],
+    },
+    'data': [
+        'data/website_slides_templates_profile.xml',
+    ],
+
     'images': [
         # 'static/description/main_screenshot.png'
         ],

--- a/viin_brand_website_slides/data/website_slides_templates_profile.xml
+++ b/viin_brand_website_slides/data/website_slides_templates_profile.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <template id="display_course" inherit_id="website_slides.display_course">
+        <xpath expr="//div[hasclass('overflow-hidden')]" position="attributes">
+            <attribute name="style"></attribute>
+        </xpath>  
+    </template>
+</odoo>

--- a/viin_brand_website_slides/static/src/scss/website_slides.scss
+++ b/viin_brand_website_slides/static/src/scss/website_slides.scss
@@ -1,0 +1,25 @@
+.o_wslides_channel_completion_progressbar .progress .progress-bar {
+    background-color: #00bbce;
+}
+.o_wslides_home_content_section .progress .progress-bar {
+    background-color: #00bbce;
+}
+.o_wslides_home_nav .navbar{
+    padding: 10px
+}
+
+.o_wprofile_nav_tabs .nav-link:not(.active):hover {
+    background: #7f4282;
+}
+
+.o_wslides_course_main .o_wslides_nav_tabs .nav-link:not(.active):hover {
+    background: #7f4282;
+}
+
+.o_wslides_course_header{
+    background: $brand-primary;
+}
+
+.o_wslides_course_pict{
+    border: none;
+}


### PR DESCRIPTION
TICKET:
---
[[BUG][18.0] viin_brand_website_slides: Một số chỗ màu sắc chưa theo màu branding Viindoo và bad UI](https://viindoo.com/web?debug=#id=59311&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Sửa lỗi bad UI, màu không đúng

HÌNH ẢNH
---

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/93395697-6b7b-4691-ad85-5404597907bc" />

<img width="1920" height="1076" alt="image" src="https://github.com/user-attachments/assets/9d09856c-7289-4680-bcc3-146718641024" />

<img width="1922" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1a537ba-7948-4914-8a75-5763e33da740" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f7eaeac2-ec47-4b48-8f0e-aef3e1853776" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ab8457b-6821-4687-a820-e23af9ddb0b0" />