### PR TITLE
[FIX][18.0] viin_brand_website: fix odoo text in HTML/CSS editor

### DIFF
--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -52,6 +52,9 @@ Editions Supported
         'web.assets_backend': [
             'viin_brand_website/static/src/components/configurator/configurator.scss',
         ],
+        'website.assets_editor': [
+            'viin_brand_website/static/src/components/resource_editor/resource_editor_warning.xml',
+        ],
     },
     'images': [
         # 'static/description/main_screenshot.png'

--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -35,7 +35,7 @@ Editions Supported
     # Check https://github.com/Viindoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Hidden',
-    'version': '0.1',
+    'version': '0.1.1',
 
     # any module necessary for this one to work correctly
     'depends': ['website'],

--- a/viin_brand_website/i18n/vi_VN.po
+++ b/viin_brand_website/i18n/vi_VN.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-26 07:21+0000\n"
-"PO-Revision-Date: 2025-09-26 07:21+0000\n"
+"POT-Creation-Date: 2025-10-13 02:52+0000\n"
+"PO-Revision-Date: 2025-10-13 02:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -45,6 +45,12 @@ msgstr "Công Ty Cổ phần Công Nghệ Viindoo."
 #: model_terms:ir.ui.view,arch_db:viin_brand_website.show_website_info
 msgid "Viindoo Version"
 msgstr "Phiên bản Viindoo"
+
+#. module: viin_brand_website
+#. odoo-javascript
+#: code:addons/viin_brand_website/static/src/components/resource_editor/resource_editor_warning.xml:0
+msgid "Your changes might be lost during future Viindoo upgrade."
+msgstr "Các thay đổi bạn thực hiện có thể bị mất khi Viindoo được nâng cấp trong các phiên bản tiếp theo."
 
 #. module: viin_brand_website
 #: model_terms:ir.ui.view,arch_db:viin_brand_website.brand_promotion
@@ -97,22 +103,3 @@ msgstr ""
 "tiêu. Sau đó, điều chỉnh tiêu đề và mô tả của bạn cho phù hợp để tăng lưu "
 "lượng truy cập."
 
-#. module: viin_brand_website
-#. odoo-javascript
-#: code:addons/viin_brand_website/static/src/xml/website_backend.xml:0
-#: model_terms:ir.ui.view,arch_db:viin_brand_website.res_config_settings_view_form
-#, python-format
-msgid "https://viindoo.com/documentation/16.0/applications.html"
-msgstr ""
-
-#. module: viin_brand_website
-#: model_terms:ir.ui.view,arch_db:viin_brand_website.res_config_settings_view_form
-msgid ""
-"https://viindoo.com/documentation/16.0/applications/websites/website/optimize/how-"
-"to-track-your-website-s-traffic-in-google-analytics.html"
-msgstr ""
-
-#. module: viin_brand_website
-#: model_terms:ir.ui.view,arch_db:viin_brand_website.brand_promotion
-msgid "https://viindoo.com/intro/website?utm_source=db&utm_medium=website"
-msgstr ""

--- a/viin_brand_website/i18n/viin_brand_website.pot
+++ b/viin_brand_website/i18n/viin_brand_website.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-26 07:21+0000\n"
-"PO-Revision-Date: 2025-09-26 07:21+0000\n"
+"POT-Creation-Date: 2025-10-13 02:49+0000\n"
+"PO-Revision-Date: 2025-10-13 02:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -41,6 +41,12 @@ msgstr ""
 #. module: viin_brand_website
 #: model_terms:ir.ui.view,arch_db:viin_brand_website.show_website_info
 msgid "Viindoo Version"
+msgstr ""
+
+#. module: viin_brand_website
+#. odoo-javascript
+#: code:addons/viin_brand_website/static/src/components/resource_editor/resource_editor_warning.xml:0
+msgid "Your changes might be lost during future Viindoo upgrade."
 msgstr ""
 
 #. module: viin_brand_website
@@ -80,22 +86,3 @@ msgid ""
 "description accordingly to boost your traffic."
 msgstr ""
 
-#. module: viin_brand_website
-#. odoo-javascript
-#: code:addons/viin_brand_website/static/src/xml/website_backend.xml:0
-#: model_terms:ir.ui.view,arch_db:viin_brand_website.res_config_settings_view_form
-#, python-format
-msgid "https://viindoo.com/documentation/16.0/applications.html"
-msgstr ""
-
-#. module: viin_brand_website
-#: model_terms:ir.ui.view,arch_db:viin_brand_website.res_config_settings_view_form
-msgid ""
-"https://viindoo.com/documentation/16.0/applications/websites/website/optimize/how-"
-"to-track-your-website-s-traffic-in-google-analytics.html"
-msgstr ""
-
-#. module: viin_brand_website
-#: model_terms:ir.ui.view,arch_db:viin_brand_website.brand_promotion
-msgid "https://viindoo.com/intro/website?utm_source=db&utm_medium=website"
-msgstr ""

--- a/viin_brand_website/static/src/components/resource_editor/resource_editor_warning.xml
+++ b/viin_brand_website/static/src/components/resource_editor/resource_editor_warning.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website.ResourceEditorWarningOverlay" t-inherit="website.ResourceEditorWarningOverlay" t-inherit-mode="extension">
+        <xpath expr="//h1[hasclass('text-dark')]" position="replace" mode="inner">
+            Your changes might be lost during future Viindoo upgrade.
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
REFERENCE:
---
[[BUG][18.0] viin_brand_website_links: Vẫn còn text và branding Odoo](https://viindoo.com/web#id=59332&cids=1&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Sửa text odoo trên HTML/CSS editoreditor

<img width="1911" height="1078" alt="image" src="https://github.com/user-attachments/assets/637997f7-e7cb-4d71-a8ce-04a0b588ab74" />
