### PR TITLE
[FIX][18.0] viin_brand_common: add Viindoo link

### DIFF
--- a/viin_brand_common/static/src/views/widgets/documentation_link/viindoo_mapping_url.js
+++ b/viin_brand_common/static/src/views/widgets/documentation_link/viindoo_mapping_url.js
@@ -116,6 +116,11 @@ export const ODOO_VIINDOO_DOCUMENTATION_MAPPING = {
         "https://viindoo.com/documentation/17.0/applications/supply-chain/purchase/manage-deals/vendor-bills-control.html",
     "https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/inventory/management/products/uom.html":
         "https://viindoo.com/documentation/17.0/applications/supply-chain/inventory/warehouse-management/products/activate-different-units-of-measure.html",
+    /* inventory */
+    "https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/inventory/product_management/product_tracking/package.html":
+        "https://viindoo.com/documentation/17.0/applications/supply-chain/inventory/warehouse-management/products/how-to-use-different-units-of-measure-packages-or-packaging.html#packages",
+    "https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/inventory/warehouses_storage/inventory_management/use_locations.html":
+        "https://viindoo.com/documentation/17.0/applications/supply-chain/inventory/warehouse-management/warehouses/how-to-create-warehouses-and-locations.html#setting-up-warehouse-locations",
     /* purchase_stock */
     "https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/inventory/shipping/operation/dropshipping.html":
         "https://viindoo.com/documentation/17.0/applications/supply-chain/inventory/warehouse-management/delivery-orders/delivery-directly-from-suppliers-to-customers-drop-ship.html",


### PR DESCRIPTION
REFERENCE:
---
[[BUG][18.0] viin_brand_stock: Link HDSD vẫn là của Odoo](https://viindoo.com/web#id=59340&cids=1&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Thay link odoo = viindoo

HÌNH ẢNH:
---
[Screencast from 16-10-2025 11:39:32.webm](https://github.com/user-attachments/assets/101227e6-972c-418f-8e46-1112e1358907)
