### PR TITLE
[FIX][18.0] viin_brand: change odoo text to viindoo

### DIFF
--- a/viin_brand_common/__init__.py
+++ b/viin_brand_common/__init__.py
@@ -1,4 +1,5 @@
 from . import controllers
+from . import models
 
 from odoo.tools import config
 

--- a/viin_brand_common/i18n/vi_VN.po
+++ b/viin_brand_common/i18n/vi_VN.po
@@ -4,25 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-21 02:37+0000\n"
-"PO-Revision-Date: 2024-05-21 02:37+0000\n"
+"POT-Creation-Date: 2025-10-16 07:26+0000\n"
+"PO-Revision-Date: 2025-10-16 07:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: viin_brand_common
-#: model_terms:ir.ui.view,arch_db:viin_brand_common.view_users_form_simple_modif
-msgid ""
-"<i title=\"Documentation\" class=\"fa fa-fw o_button_icon fa-info-circle\"/>\n"
-"                    Learn more"
-msgstr ""
-"<i title=\"Tài liệu\" class=\"fa fa-fw o_button_icon fa-info-circle\"/>\n"
-"                    Tìm hiểu thêm"
 
 #. module: viin_brand_common
 #: model_terms:ir.ui.view,arch_db:viin_brand_common.login_layout
@@ -35,8 +26,8 @@ msgid ""
 "API Keys are used to connect to Viindoo from external tools without the need"
 " for a password or Two-factor Authentication."
 msgstr ""
-"Khóa API được sử dụng để kết nối với Viindoo từ các công cụ bên ngoài mà không "
-"cần mật khẩu hoặc Xác thực hai yếu tố."
+"Khóa API được sử dụng để kết nối với Viindoo từ các công cụ bên ngoài mà "
+"không cần mật khẩu hoặc Xác thực hai yếu tố."
 
 #. module: viin_brand_common
 #: model_terms:ir.ui.view,arch_db:viin_brand_common.view_module_filter
@@ -56,21 +47,40 @@ msgstr "Kiểm tra lại"
 #. module: viin_brand_common
 #: model_terms:ir.ui.view,arch_db:viin_brand_common.webclient_offline
 msgid ""
+"Check your network connection and come back here. Viindoo will load as soon "
+"as you're back online."
+msgstr ""
 "Kiểm tra kết nối mạng của bạn và quay lại đây. Viindoo sẽ tải ngay "
 "khi bạn trực tuyến trở lại."
+
+#. module: base
+#: model:ir.model.fields,help:base.field_ir_mail_server__from_filter
+msgid ""
+"Comma-separated list of addresses or domains for which this server can be used.\n"
+"e.g.: \"notification@viindoo.com\" or \"viindoo.com\""
 msgstr ""
+"Danh sách các địa chỉ hoặc tên miền được phân tách bằng dấu phẩy mà máy chủ này có thể được sử dụng.\n"
+"VD: \"notification@viindoo.com\" or \"viindoo.com\""
 
 #. module: viin_brand_common
 #. odoo-javascript
 #: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
-#, python-format
 msgid "Documentation"
 msgstr "Tài liệu"
 
 #. module: viin_brand_common
+#: model:ir.model.fields,field_description:viin_brand_common.field_ir_mail_server__from_filter
+msgid "FROM Filtering"
+msgstr "Bộ lọc TỪ"
+
+#. module: viin_brand_common
+#: model:ir.model,name:viin_brand_common.model_ir_mail_server
+msgid "Mail Server"
+msgstr "Máy chủ gửi thư"
+
+#. module: viin_brand_common
 #. odoo-javascript
 #: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
-#, python-format
 msgid "My Viindoo.com account"
 msgstr "Tài khoản Viindoo.com"
 
@@ -82,7 +92,6 @@ msgstr "Ngoại tuyến"
 #. module: viin_brand_common
 #. odoo-javascript
 #: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
-#, python-format
 msgid "Support"
 msgstr "Hỗ trợ"
 

--- a/viin_brand_common/i18n/viin_brand_common.pot
+++ b/viin_brand_common/i18n/viin_brand_common.pot
@@ -4,23 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-21 02:37+0000\n"
-"PO-Revision-Date: 2024-05-21 02:37+0000\n"
+"POT-Creation-Date: 2025-10-16 07:26+0000\n"
+"PO-Revision-Date: 2025-10-16 07:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: viin_brand_common
-#: model_terms:ir.ui.view,arch_db:viin_brand_common.view_users_form_simple_modif
-msgid ""
-"<i title=\"Documentation\" class=\"fa fa-fw o_button_icon fa-info-circle\"/>\n"
-"                    Learn more"
-msgstr ""
 
 #. module: viin_brand_common
 #: model_terms:ir.ui.view,arch_db:viin_brand_common.login_layout
@@ -56,17 +49,32 @@ msgid ""
 "as you're back online."
 msgstr ""
 
-#. module: viin_brand_common
-#. odoo-javascript
-#: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
-#, python-format
-msgid "Documentation"
+#. module: base
+#: model:ir.model.fields,help:base.field_ir_mail_server__from_filter
+msgid ""
+"Comma-separated list of addresses or domains for which this server can be used.\n"
+"e.g.: \"notification@viindoo.com\" or \"viindoo.com\""
 msgstr ""
 
 #. module: viin_brand_common
 #. odoo-javascript
 #: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
-#, python-format
+msgid "Documentation"
+msgstr ""
+
+#. module: viin_brand_common
+#: model:ir.model.fields,field_description:viin_brand_common.field_ir_mail_server__from_filter
+msgid "FROM Filtering"
+msgstr ""
+
+#. module: viin_brand_common
+#: model:ir.model,name:viin_brand_common.model_ir_mail_server
+msgid "Mail Server"
+msgstr ""
+
+#. module: viin_brand_common
+#. odoo-javascript
+#: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
 msgid "My Viindoo.com account"
 msgstr ""
 
@@ -78,7 +86,6 @@ msgstr ""
 #. module: viin_brand_common
 #. odoo-javascript
 #: code:addons/viin_brand_common/static/src/webclient/user_menu_item.js:0
-#, python-format
 msgid "Support"
 msgstr ""
 

--- a/viin_brand_common/models/__init__.py
+++ b/viin_brand_common/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_mail_server

--- a/viin_brand_common/models/ir_mail_server.py
+++ b/viin_brand_common/models/ir_mail_server.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class IrMailServer(models.Model):
+    _inherit = 'ir.mail_server'
+
+    from_filter = fields.Char(
+        help="Comma-separated list of addresses or domains for which this server can be used.\n"
+             "e.g.: 'notification@viindoo.com' or 'viindoo.com")

--- a/viin_brand_mail_bot/i18n/vi_VN.po
+++ b/viin_brand_mail_bot/i18n/vi_VN.po
@@ -80,6 +80,16 @@ msgstr ""
 "target=\"_blank\">video của chúng tôi</a>."
 
 #. module: viin_brand_mail_bot
+#: model:ir.model,name:viin_brand_mail_bot.model_res_users
+msgid "User"
+msgstr "Người dùng"
+
+#. module: viin_brand_mail_bot
+#: model:ir.model.fields,field_description:viin_brand_mail_bot.field_res_users__odoobot_state
+msgid "ViindooBot Status"
+msgstr "Tình trạng ViindooBot"
+
+#. module: viin_brand_mail_bot
 #. odoo-python
 #: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
 msgid ""

--- a/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
+++ b/viin_brand_mail_bot/i18n/viin_brand_mail_bot.pot
@@ -62,6 +62,16 @@ msgid ""
 msgstr ""
 
 #. module: viin_brand_mail_bot
+#: model:ir.model,name:viin_brand_mail_bot.model_res_users
+msgid "User"
+msgstr ""
+
+#. module: viin_brand_mail_bot
+#: model:ir.model.fields,field_description:viin_brand_mail_bot.field_res_users__odoobot_state
+msgid "ViindooBot Status"
+msgstr ""
+
+#. module: viin_brand_mail_bot
 #. odoo-python
 #: code:addons/viin_brand_mail_bot/models/mail_bot.py:0
 msgid ""

--- a/viin_brand_mail_bot/models/__init__.py
+++ b/viin_brand_mail_bot/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mail_bot
+from . import res_user

--- a/viin_brand_mail_bot/models/res_user.py
+++ b/viin_brand_mail_bot/models/res_user.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    # Override to branding
+    odoobot_state = fields.Selection(string='ViindooBot Status')


### PR DESCRIPTION
REFERENCE:
---
[[BUG] viin_brand_mail: Có nhiều help chưa được thay thế link của odoo sang Viindoo](https://viindoo.com/web?debug=#id=55007&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Thay text của odoo thành viindoo

HÌNH ẢNH:
---

<img width="1919" height="1072" alt="image" src="https://github.com/user-attachments/assets/415bc88f-f993-498d-857f-de2ae73d0bdc" />

<img width="1919" height="1072" alt="image" src="https://github.com/user-attachments/assets/e79c6e8f-1d20-47b5-bad1-8edef32230e0" />
