### PR TITLE
[FIX][18.0] viin_brand: bad UI 2

### DIFF
--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -68,6 +68,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
             # common branding
             'viin_brand_common/static/src/legacy/scss/navbar.scss',
             'viin_brand_common/static/src/legacy/scss/systray.scss',
+            ('after', 'web/static/src/core/emoji_picker/emoji_picker.scss', 'viin_brand_common/static/src/core/emoji_picker/emoji_picker.scss'),
             ('after', 'web/static/src/webclient/webclient.scss', 'viin_brand_common/static/src/webclient/webclient.scss'),
             ('after', 'web/static/src/search/search_panel/search_view.scss', 'viin_brand_common/static/src/search/search_panel/search_view.scss'),
             ('after', 'web/static/src/search/search_bar/search_bar.scss', 'viin_brand_common/static/src/search/search_bar/search_bar.scss'),
@@ -80,6 +81,12 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
             'viin_brand_common/static/src/webclient/navbar/navbar.scss',
             'viin_brand_common/static/src/webclient/user_menu_item.js',
             'viin_brand_common/static/src/views/widgets/**/*',
+        ],
+        'mail.assets_public': [
+            ('after', 'web/static/src/core/emoji_picker/emoji_picker.scss', 'viin_brand_common/static/src/core/emoji_picker/emoji_picker.scss'),
+        ],
+        'im_livechat.assets_embed_core': [
+            ('after', 'web/static/src/core/emoji_picker/emoji_picker.scss', 'viin_brand_common/static/src/core/emoji_picker/emoji_picker.scss'),
         ],
     },
     'installable': True,

--- a/viin_brand_common/static/src/core/emoji_picker/emoji_picker.scss
+++ b/viin_brand_common/static/src/core/emoji_picker/emoji_picker.scss
@@ -1,0 +1,3 @@
+.o-EmojiPicker .o-EmojiPicker-navbar .o-Emoji > span {
+    filter: none;
+}

--- a/viin_brand_im_livechat/__manifest__.py
+++ b/viin_brand_im_livechat/__manifest__.py
@@ -44,6 +44,11 @@ Editions Supported
     'demo': [
         'data/im_livechat_channel_demo.xml'
     ],
+    'assets': {
+        'im_livechat.assets_embed_core': [
+            'viin_brand_im_livechat/static/src/embed/common/livechat_button.xml',
+        ],
+    },
     'data': [
         'data/digest_data.xml',
         'data/im_livechat_chatbot_data.xml',

--- a/viin_brand_im_livechat/static/src/embed/common/livechat_button.xml
+++ b/viin_brand_im_livechat/static/src/embed/common/livechat_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="im_livechat.LivechatButton" t-inherit-mode="extension">
+        <xpath expr="//button" position="attributes">
+            <attribute name="t-attf-style">
+                color: {{livechatService.options.button_text_color}}; background-color: #00bbce; width: {{size}}px; height: {{size}}px; min-width: 56px; top: {{ position.top }}; left: {{ position.left }};
+            </attribute>
+        </xpath>
+    </t>
+</templates>

--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -61,6 +61,16 @@ Editions Supported
             ('after', 'mail/static/src/core/public_web/discuss_sidebar.scss', 'viin_brand_mail/static/src/core/web/discuss_sidebar.scss'),
             ('after', 'mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss', 'viin_brand_mail/static/src/discuss/core/web/discuss_sidebar_categories.scss'),
         ],
+        'mail.assets_public': [
+            ('after', 'mail/static/src/core/common/chat_window.scss', 'viin_brand_mail/static/src/core/common/chat_window.scss'),
+            ('after', 'mail/static/src/core/common/im_status.scss', 'viin_brand_mail/static/src/core/common/im_status.scss'),
+            ('after', 'mail/static/src/core/common/composer.scss', 'viin_brand_mail/static/src/core/common/composer.scss'),
+        ],
+        'im_livechat.assets_embed_core': [
+            ('after', 'mail/static/src/core/common/chat_window.scss', 'viin_brand_mail/static/src/core/common/chat_window.scss'),
+            ('after', 'mail/static/src/core/common/im_status.scss', 'viin_brand_mail/static/src/core/common/im_status.scss'),
+            ('after', 'mail/static/src/core/common/composer.scss', 'viin_brand_mail/static/src/core/common/composer.scss'),
+        ],
     },
     'installable': True,
     'auto_install': True,

--- a/viin_brand_mail/static/src/core/common/chat_window.scss
+++ b/viin_brand_mail/static/src/core/common/chat_window.scss
@@ -1,3 +1,21 @@
 .o-mail-ChatWindow-header {
     background-color: $brand-primary-dark !important;
+    color: white;
+    --mail-ChatWindow-commandHoverColor: white;
+
+    .o-mail-ChatWindow-quickActions .o-mail-ChatWindow-command {
+        color: white !important;
+    }
+
+    .o-mail-ChatWindow-quickActions .o-mail-ChatWindow-command.o-quick {
+        opacity: 1;
+    }
+
+    .o-mail-ChatWindow-command .fa-caret-down {
+        color: white !important;
+    }
+
+    .o-mail-ChatWindow-command:not(.o-active):not(.o-hover) .fa-caret-down {
+        opacity: 1;
+    }
 }

--- a/viin_brand_mail/static/src/core/common/composer.scss
+++ b/viin_brand_mail/static/src/core/common/composer.scss
@@ -1,3 +1,28 @@
 .o-mail-Composer-input {
     min-height: 43px !important;
 }
+
+.o-mail-Composer-actions {
+    button {
+        &.o-mail-Composer-send.btn-link:not(:disabled) {
+            background-color: $brand-primary !important;
+        }
+    }
+}
+
+.o-mail-Composer-bg:has(textarea:focus) {
+    border-color: $brand-primary !important;
+    box-shadow:
+        0 0 4px rgba($brand-primary, 0.4),
+        0 0 8px rgba($brand-primary, 0.3);
+    transition: all 0.25s ease;
+}
+
+.o-mail-ChatWindow .o-mail-Composer-bg {
+    align-items: center;
+}
+
+.o-mail-Composer-input {
+    padding-top: 10px !important;
+    padding-bottom: 10px !important;
+}


### PR DESCRIPTION
REFERENCE:
---
[[BUG][18.0] viin_brand_mail_bot: Giao diện vẫn còn nhiều chỗ chưa theo màu branding Viindoo](https://viindoo.com/web#id=59312&cids=1&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
- Sửa Bad UI

HÌNH ẢNH:
---

<img width="1920" height="1076" alt="image" src="https://github.com/user-attachments/assets/be8ea6aa-2e8b-4644-88d6-d58b5f0e84ea" />

<img width="537" height="778" alt="image" src="https://github.com/user-attachments/assets/7df368a9-dcac-41c0-93db-ea54d5b036bb" />

<img width="193" height="227" alt="image" src="https://github.com/user-attachments/assets/39877a03-01dc-4958-969e-6e4fa33f6b39" />
