### PR TITLE
[FIX][18.0] viin_brand_website_event: fix odoo text to viindoo

### DIFF
--- a/viin_brand_website_event/data/event_demo.xml
+++ b/viin_brand_website_event/data/event_demo.xml
@@ -1,4 +1,40 @@
 <odoo>
+
+    <record id="event.event_0" model="event.event">
+        <field name="description" type="html">
+            <div class="oe_structure">
+                <h5>Join us for this 3-day Event</h5>
+                <p class="lead mb-3">Every year we invite our community, partners and end-users to come and meet us! It's the ideal event to get together and present new features, roadmap of future versions, achievements of the software, workshops, training sessions, etc....</p>
+                <p class="mb-3">This event is also an opportunity to showcase our partners' case studies, methodology or developments. Be there and see directly from the source the features of the version 12!
+                </p>
+                <div class="text-bg-light border-start border-2 border-secondary p-3">
+                    <p class="mb-0"><i class="fa fa-info-circle me-2"/>This event and all the conferences are in <b>English</b>!</p>
+                </div>
+                <h5 class="mb-2">What's new?</h5>
+                <ul class="mb-5">
+                    <li class="mb-2"><b>The Design Fair is preceded by 2 days of Training Sessions for experts!</b><br/> We propose 3 different training sessions, 2 days each.</li>
+                    <li class="mb-2"><b>The whole event is open to all public!</b> <br/>We ask a participation fee of 49.50€ for the costs for the 3 days (coffee breaks, catering, drinks and a surprising concert and beer party).<br/> For those who don't want to contribute, there is a free ticket, therefore, catering and access to evening events aren't included.</li>
+                    <li class="mb-2"><b>The plenary sessions in the morning will be shorter</b> and we will give more time for thematical meetings, conferences, workshops and tutorial sessions in the afternoon.</li>
+                </ul>
+                <h5 class="mb-2">Program</h5>
+                <p>Conferences, workshops and trainings will be organized in 6 rooms:</p>
+                <ul class="mb-5">
+                    <li><b>Technical Rooms</b> - One dedicated to advanced Viindoo developers, one for new developers.</li>
+                    <li><b>Technical Rooms</b> - One dedicated to advanced Viindoo developers, one for new developers.</li>
+                    <li><b>Business Room</b> - To discuss implementation methodologies, best sales practices, etc.</li>
+                    <li><b>Workshop Room</b> - Mainly for developers.</li>
+                </ul>
+                <div class="rounded-end border-start border-secondary p-3 mb-3" style="border-start-width: 3px !important;">
+                    <p class="mb-0"><em>If you wish to make a presentation, please send your topic proposal as soon as possible for approval to Mr. Famke Jenssens at ngh (a) yourcompany (dot) com. The presentations should be, for example, a presentation of a community module, a case study, methodology feedback, technical, etc. Each presentation must be in English.</em></p>
+                </div>
+                <p class="mb-3">For any additional information, please contact us at <a href="mailto:events@yourcompany.com">events@yourcompany.com</a>.</p>
+                <div class="text-bg-light border-start border-2 border-secondary p-3">
+                    <p class="mb-0">OpenElec Applications reserves the right to cancel, re-name or re-locate the event or change the dates on which it is held.</p>
+                </div>
+            </div>
+        </field>
+    </record>
+
 	<record id="event.event_2" model="event.event">
         <field name="website_published" eval="True"/>
         <field name="subtitle">Enhance your architectural business and improve professional skills.</field>

--- a/viin_brand_website_event/i18n/vi_VN.po
+++ b/viin_brand_website_event/i18n/vi_VN.po
@@ -1,0 +1,25 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-21 06:23+0000\n"
+"PO-Revision-Date: 2025-10-21 06:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: event
+#: model_terms:event.event,description:event.event_0
+#: model_terms:event.event,description:event.event_2
+msgid ""
+"<b>Technical Rooms</b> - One dedicated to advanced Viindoo developers, one "
+"for new developers."
+msgstr ""
+"<b>Phòng kỹ thuật</b> - Một phòng dành cho các lập trình viên Viindoo nâng cao, một phòng "
+"dành cho các lập trình viên mới."

--- a/viin_brand_website_event/i18n/viin_brand_website_event.pot
+++ b/viin_brand_website_event/i18n/viin_brand_website_event.pot
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-21 06:23+0000\n"
+"PO-Revision-Date: 2025-10-21 06:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: event
+#: model_terms:event.event,description:event.event_0
+#: model_terms:event.event,description:event.event_2
+msgid ""
+"<b>Technical Rooms</b> - One dedicated to advanced Viindoo developers, one "
+"for new developers."
+msgstr ""


### PR DESCRIPTION
REFERENCE:
---
[[BUG][18.0] viin_brand_website_event: Vẫn còn có text Odoo trong bài viết](https://viindoo.com/web?debug=#id=59315&cids=1&menu_id=89&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
---
Sửa text odoo thành viindoo

HÌNH ẢNH:
---

<img width="1918" height="1080" alt="image" src="https://github.com/user-attachments/assets/907bd167-fef2-47b5-b5b7-77b1af929715" />
