### PR TITLE
[FIX][17.0] viin_brand_mrp: Fix Bad UI

### DIFF
--- a/viin_brand_mrp/__manifest__.py
+++ b/viin_brand_mrp/__manifest__.py
@@ -52,6 +52,7 @@ Module này sẽ thay đổi giao diện các module Manufacturing theo thương
     # always loaded
     'data': [
         'data/digest_data.xml',
+        'views/mrp_production_views.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/viin_brand_mrp/views/mrp_production_views.xml
+++ b/viin_brand_mrp/views/mrp_production_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <record id="mrp_production_form_inherit" model="ir.ui.view">
+        <field name="name">mrp.production.form</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_qty']" position="attributes">
+                <attribute name="style">width: 50% !important;</attribute>
+            </xpath>
+            <xpath expr="//field[@groups='uom.group_uom']" position="attributes">
+                <attribute name="style">width: 50% !important;</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
REFERENCE:
[Zoom màn hình Chrome > 80% sẽ bị ẩn mất trường Số lượng trên lênh sản xuất](https://viindoo.com/web#id=60423&menu_id=89&model=viin.helpdesk.ticket&view_type=form)

PR NÀY ĐỂ:
- Lỗi này do không chia width nên khi zoom bị đè field nên e sẽ chia đều 50% 2 bên

HÌNH ẢNH:

<img width="1204" height="668" alt="image" src="https://github.com/user-attachments/assets/9ce7dbf1-d159-480a-8a04-6a5f5ef05380" />
