### PR TITLE
[FIX] web_responsive: Don't override z-index of toolbar

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -150,12 +150,6 @@ $chatter_zone_width: 35% !important;
     }
 }
 
-body:not(.o_statusbar_buttons) {
-    .oe-toolbar {
-        z-index: 0 !important;
-    }
-}
-
 .o_inner_group > .mb-sm-0 {
     margin-bottom: 0 !important;
 }


### PR DESCRIPTION
Before this changes when trying to edit a message using web_editor, the toolbar is showed behind the wizard.

After this changes, it is showed correctly.