### PR TITLE
[IMP] gitignore: ignore node_modules and .odoo-ai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,9 @@ install/win32/meta.py
 Icon?
 ehthumbs.db
 Thumbs.db
+
+# Node.js dependencies
+node_modules/
+
+# Odoo AI agent workspace
+.odoo-ai/


### PR DESCRIPTION
## What
Ignore two local directories in `.gitignore`:
- `node_modules/` - Node.js dependencies
- `.odoo-ai/` - local AI agent working directory

## Why
Keep local build and tooling artifacts out of version control.

## Notes
- Trailing slash makes each pattern match the directory and all its contents (including a nested `node_modules/` inside any addon).
- `node_modules` was not previously ignored.
- `.odoo-ai` was already covered by the existing `.*` dotfile rule; this entry makes the intent explicit.