### PR TITLE
[FIX] web_responsive: semantic SCSS tokens + guard apps_menu access

### DIFF
--- a/web_responsive/static/src/components/menu_searchbar/searchbar.esm.js
+++ b/web_responsive/static/src/components/menu_searchbar/searchbar.esm.js
@@ -11,7 +11,7 @@ import { session } from "@web/session";
 export class AppsMenuSearchBar extends Component {
     setup() {
         super.setup();
-        this.searchType = session.apps_menu.search_type || "canonical";
+        this.searchType = session.apps_menu?.search_type || "canonical";
     }
 }
 

--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -100,17 +100,17 @@ $chatter_zone_width: 35% !important;
             position: sticky !important;
             top: 0;
             z-index: 2;
-            border-top: 0.5px solid #dee2e6;
-            border-bottom: 0.5px solid #dee2e6;
+            border-top: 0.5px solid $border-color;
+            border-bottom: 0.5px solid $border-color;
             padding-bottom: 0px !important;
-            background: white;
+            background: $white;
         }
 
         .o_form_sheet_bg {
             padding-top: 0;
             padding-left: 0;
             padding-right: 0;
-            border-right: 1px solid #dee2e6;
+            border-right: 1px solid $border-color;
         }
 
         .o_statusbar_buttons {
@@ -118,7 +118,7 @@ $chatter_zone_width: 35% !important;
         }
 
         .o_form_sheet {
-            margin: 8px 32px
+            margin: 8px 32px;
         }
         @include media-breakpoint-down(sm) {
             min-width: auto;


### PR DESCRIPTION
## web_responsive UI follow-ups (from PR #643 review)

Three small fixes flagged during the 17.0 → 18.0 forward-port review (PR #643), landed on 17.0 so they forward-port naturally to 18.0.

- **SCSS semantic tokens** (`static/src/legacy/scss/web_responsive.scss`): replace hardcoded `#dee2e6` → `$border-color` (3×) and `background: white` → `background: $white` in the `.o_form_statusbar` / `.o_form_sheet_bg` block — aligns with the file's own convention (it already uses both vars) so the block now tracks theme overrides.
- **Trailing semicolon**: `margin: 8px 32px` → `margin: 8px 32px;`.
- **Undefined guard** (`static/src/components/menu_searchbar/searchbar.esm.js`): `session.apps_menu.search_type` → `session.apps_menu?.search_type` (fallback `|| "canonical"` preserved) — prevents "Cannot read properties of undefined" in QUnit/tour mock contexts; same pattern as the apps_menu `?.theme` guard.

Pure style-token + safety refactor; no behavior change beyond the guard. JS syntax validated; SCSS vars proven resolvable in-file.