### PR TITLE
[FIX] web_responsive: don't break core component tests when apps_menu is

### DIFF
--- a/web_responsive/static/src/components/navbar/navbar.js
+++ b/web_responsive/static/src/components/navbar/navbar.js
@@ -1,14 +1,17 @@
 /** @odoo-module **/
 
 import { NavBar } from "@web/webclient/navbar/navbar";
-import { useBus, useService } from "@web/core/utils/hooks";
+import { useBus } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { useRef } from "@odoo/owl";
 
 patch(NavBar.prototype, {
     setup() {
         super.setup();
-        this.appsMenuService = useService("apps_menu");
+        // Read apps_menu optionally: the NavBar is mounted by isolated core
+        // component tests that do not start this service, and useService() would
+        // throw and break them as soon as web_responsive is installed.
+        this.appsMenuService = this.env.services.apps_menu;
         this.homeMenuButton = useRef("homeMenuButton");
         useBus(this.env.bus, "TOGGLE_HOME_MENU_BUTTON", ({ detail: toggle }) => {
             this.homeMenuButton.el.classList.toggle("d-none", toggle);

--- a/web_responsive/static/src/components/webclient/webclient.js
+++ b/web_responsive/static/src/components/webclient/webclient.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { useService } from "@web/core/utils/hooks";
 import { WebClient } from "@web/webclient/webclient";
 import { patch } from "@web/core/utils/patch";
 
@@ -8,9 +7,14 @@ import { patch } from "@web/core/utils/patch";
 patch(WebClient.prototype, {
     setup() {
         super.setup();
-        this.appsMenuService = useService("apps_menu");
+        // Read apps_menu optionally so isolated core WebClient tests (which do
+        // not start this service) keep working once web_responsive is installed.
+        this.appsMenuService = this.env.services.apps_menu;
     },
     _loadDefaultApp() {
-        return this.appsMenuService.toggleMenu(true);
+        if (this.appsMenuService) {
+            return this.appsMenuService.toggleMenu(true);
+        }
+        return super._loadDefaultApp();
     },
 });


### PR DESCRIPTION
Fix lỗi cho PR https://github.com/Viindoo/tvtmaaddons/pull/14184 để kích hoạt test tour

The NavBar and WebClient patches called useService("apps_menu") and the menu searchbar read session.apps_menu.search_type. Isolated core component tests (NavBar, BurgerMenu, mail mobile) do not start apps_menu nor set session.apps_menu, so these threw as soon as web_responsive is installed ("Service apps_menu is not available", "Cannot read properties of undefined (reading 'search_type')"). Read apps_menu from env.services (optional), fall back to super._loadDefaultApp(), and use session.apps_menu?.search_type.