### PR TITLE
[IMP] *: point module manifests at their canonical App Store page

### DIFF
--- a/to_backend_theme/__manifest__.py
+++ b/to_backend_theme/__manifest__.py
@@ -13,7 +13,7 @@ Backend theme for Viindoo, based on the Openworx Backend Theme
     """,
 
     'author': 'Openworx,T.V.T Marine Automation,Viindoo',
-    'website': 'https://viindoo.com',
+    'website': 'https://viindoo.com/apps/modules/17.0/to_backend_theme',
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': 'apps.support@viindoo.com',

--- a/viin_brand/__manifest__.py
+++ b/viin_brand/__manifest__.py
@@ -31,7 +31,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
     """,
 
     'author': "Viindoo",
-    'website': "https://www.tvtmarine.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "support@ma.tvtmarine.com",

--- a/viin_brand/apriori.py
+++ b/viin_brand/apriori.py
@@ -13,7 +13,7 @@ modules_website = {
     'hr_expense': 'https://viindoo.com/intro/expense',
     'hr_holidays': 'https://viindoo.com/intro/time-off',
     'hr_recruitment': 'https://viindoo.com/intro/recruitment',
-    'hr_contract': 'https://viindoo.com/apps/app/15.0/viin_hr_contract',
+    'hr_contract': 'https://viindoo.com/apps/modules/17.0/viin_hr_contract',
     # 'hr_skills': '',
     'im_livechat': 'https://viindoo.com/intro/live-chat',
     # 'lunch': '',

--- a/viin_brand_account/__manifest__.py
+++ b/viin_brand_account/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Invoicing theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_account?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_oauth/__manifest__.py
+++ b/viin_brand_auth_oauth/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module OAuth2 Authentication theo thư�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_oauth?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_totp/__manifest__.py
+++ b/viin_brand_auth_totp/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication theo t
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_totp?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_totp_mail_enforce/__manifest__.py
+++ b/viin_brand_auth_totp_mail_enforce/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication By Mai
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_totp_mail_enforce?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_totp_portal/__manifest__.py
+++ b/viin_brand_auth_totp_portal/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module TOTPortal theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_totp_portal?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_base_import/__manifest__.py
+++ b/viin_brand_base_import/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Base import theo thương hiệu
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_base_import?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_base_setup/__manifest__.py
+++ b/viin_brand_base_setup/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Initial Setup Tools theo thươn
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_base_setup?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_calendar/__manifest__.py
+++ b/viin_brand_calendar/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Calendar theo thương hiệu Vi
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_calendar?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -31,7 +31,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
     """,
 
     'author': "Viindoo",
-    'website': " https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_common?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_contacts/__manifest__.py
+++ b/viin_brand_contacts/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Contacts theo thương hiệu Vi
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_contacts?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_crm/__manifest__.py
+++ b/viin_brand_crm/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module CRM theo thương hiệu Viindoo
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_crm?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_digest/__manifest__.py
+++ b/viin_brand_digest/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Digest theo thương hiệu Viin
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_digest?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_fleet/__manifest__.py
+++ b/viin_brand_fleet/__manifest__.py
@@ -31,7 +31,7 @@ Module này sẽ thay đổi giao diện module Fleet theo thương hiệu Viind
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_fleet?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr/__manifest__.py
+++ b/viin_brand_hr/__manifest__.py
@@ -33,7 +33,7 @@ Module này sẽ thay đổi giao diện module Employees theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr_expense/__manifest__.py
+++ b/viin_brand_hr_expense/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Hr Expense theo thương hiệu 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr_expense?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr_recruitment/__manifest__.py
+++ b/viin_brand_hr_recruitment/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Recruitment theo thương hiệu
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr_recruitment?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr_skills/__manifest__.py
+++ b/viin_brand_hr_skills/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Skills Management theo thương 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr_skills?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_im_livechat/__manifest__.py
+++ b/viin_brand_im_livechat/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_im_livechat?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_im_livechat_mail_bot/__manifest__.py
+++ b/viin_brand_im_livechat_mail_bot/__manifest__.py
@@ -34,7 +34,7 @@ Module này sẽ thay đổi giao diện module Tôi là Chat Bot Trực tuyến
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_im_livechat_mail_bot?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_l10n_vn/__manifest__.py
+++ b/viin_brand_l10n_vn/__manifest__.py
@@ -28,7 +28,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_l10n_vn?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -29,7 +29,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mail?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mail_bot/__manifest__.py
+++ b/viin_brand_mail_bot/__manifest__.py
@@ -34,7 +34,7 @@ Module này sẽ thay đổi giao diện module Mail Bot theo thương hiệu Vi
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mail_bot?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mail_plugin/__manifest__.py
+++ b/viin_brand_mail_plugin/__manifest__.py
@@ -28,7 +28,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mail_plugin?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing/__manifest__.py
+++ b/viin_brand_mass_mailing/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Email Marketing theo thươ
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_crm/__manifest__.py
+++ b/viin_brand_mass_mailing_crm/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Lead / Oppo
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_crm?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_sale/__manifest__.py
+++ b/viin_brand_mass_mailing_sale/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Sale Orders
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_sale?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_sms/__manifest__.py
+++ b/viin_brand_mass_mailing_sms/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module SMS Marketing theo thương
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_sms?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_themes/__manifest__.py
+++ b/viin_brand_mass_mailing_themes/__manifest__.py
@@ -28,7 +28,7 @@ Module này sẽ thay đổi giao diện module Mass Mailing Themes theo thươn
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_themes?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_membership/__manifest__.py
+++ b/viin_brand_membership/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Members theo thương hiệu Vii
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_membership?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mrp/__manifest__.py
+++ b/viin_brand_mrp/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Manufacturing theo thương
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mrp?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_onboarding/__manifest__.py
+++ b/viin_brand_onboarding/__manifest__.py
@@ -29,7 +29,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': " https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_onboarding?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_payment/__manifest__.py
+++ b/viin_brand_payment/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Payment Provider theo thư�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_payment?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_payment_paypal/__manifest__.py
+++ b/viin_brand_payment_paypal/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Paypal Payment Acquirer the
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_payment_paypal?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_portal/__manifest__.py
+++ b/viin_brand_portal/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện các module Portal theo thương hiệu
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_portal?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_pos/__manifest__.py
+++ b/viin_brand_pos/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi màu sắc của thanh điều hướng (navbar), c
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_pos?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_pos_mercury/__manifest__.py
+++ b/viin_brand_pos_mercury/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Vantiv Payment Services the
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_pos_mercury?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_product/__manifest__.py
+++ b/viin_brand_product/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Product theo thương hiệ
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_product?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_purchase/__manifest__.py
+++ b/viin_brand_purchase/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Purchase theo thương hi�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_purchase?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_sale/__manifest__.py
+++ b/viin_brand_sale/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Sale theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_sale?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_sale_management/__manifest__.py
+++ b/viin_brand_sale_management/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Sales theo thương hiệu 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_sale_management?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_sale_pdf_quote_builder/__manifest__.py
+++ b/viin_brand_sale_pdf_quote_builder/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_sale_pdf_quote_builder?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_snailmail/__manifest__.py
+++ b/viin_brand_snailmail/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Snail Mail theo thương hi
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_snailmail?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_social_media/__manifest__.py
+++ b/viin_brand_social_media/__manifest__.py
@@ -33,7 +33,7 @@ Module này sẽ thay đổi giao diện các module Social Media theo thương 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_social_media?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_stock/__manifest__.py
+++ b/viin_brand_stock/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Stock theo thương hiệu 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_stock?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_web/__manifest__.py
+++ b/viin_brand_web/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_web?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_web_editor/__manifest__.py
+++ b/viin_brand_web_editor/__manifest__.py
@@ -21,7 +21,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': " https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_web_editor?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_web_unsplash/__manifest__.py
+++ b/viin_brand_web_unsplash/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện cuả Unsplash Image Library theo thư�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_web_unsplash?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_event/__manifest__.py
+++ b/viin_brand_website_event/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Events theo thương hiệu Viin
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_event?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_event_exhibitor/__manifest__.py
+++ b/viin_brand_website_event_exhibitor/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Event Exhibitors theo thương h
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_event_exhibitor?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_forum/__manifest__.py
+++ b/viin_brand_website_forum/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Forum theo thương hiệu Viind
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_forum?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_jitsi/__manifest__.py
+++ b/viin_brand_website_jitsi/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Jitsi theo thương hiệu Viind
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_jitsi?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_links/__manifest__.py
+++ b/viin_brand_website_links/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Link Tracker theo thương hiệ
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_links?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_profile/__manifest__.py
+++ b/viin_brand_website_profile/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_profile?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_sale/__manifest__.py
+++ b/viin_brand_website_sale/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_sale?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_slides/__manifest__.py
+++ b/viin_brand_website_slides/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_slides?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",


### PR DESCRIPTION
## What

Point this repo's module manifests at their real App Store page, `https://viindoo.com/apps/modules/17.0/<technical_name>`, and repair one shipped branding link.

`/apps/modules/` is the **Odoo-Apps-Store-standard** URL form; the Viindoo-invented `/apps/app/` form becomes a permanent 301 shim in Viindoo/tvtmaaddons#14239. This PR is independent of that one.

## Scope

**58 / 58** in-scope manifests — **57** with `?force_show=1`, **1** bare (`to_backend_theme`, whose category is `Website/Theme/Backend`, not `Hidden`). All were pointing at a bare homepage; none advertised a real module page. This is a **rewrite of an existing value — zero key insertions**.

Second commit: `viin_brand/apriori.py:16`. That dict is **shipped, not inert** — `to_base` overrides a core module's manifest `website` from it at load time (`_get_brand_module_website` -> `_load_manifest_plus`), so its value is what a deployment actually displays for core `hr_contract`. It was wrong twice over: the legacy `/apps/app/` prefix **and** a `15.0` version pinned inside the 17.0 branch, sending 17.0 users to a four-series-old page. The other ~30 entries map core Odoo modules to Viindoo **marketing intro pages** and are deliberately untouched — a core Odoo module has no store page under its own name, so an intro page is the correct destination.

## The exclusion rule is CODE OWNERSHIP, never the domain a link points at

- **`web_responsive` is excluded** and left byte-identical — unmodified third-party OCA code (author OCA, LGPL-3, `website` pointing at github.com/OCA/web). Its metadata is untouched.
- **`viin_brand` IS swept**, even though its old value pointed at a reseller domain rather than viindoo.com — Viindoo owns the code.

Two modules point off-domain; only one is third-party. **A domain-keyed rule excludes both and is wrong.**

## Verification

All manifests parse under `ast.literal_eval` on both revisions; key set, key order, every non-`website` value and per-file quote style are byte-identical across all 58. The `?force_show=1` split was checked against `category == 'Hidden'` as an exact match against every raw category string in the repo — no near-miss substrings. Idempotent: a second pass edits 0 files. `viin_brand/apriori.py` still parses and its dict still loads (32 entries); residual `/apps/app/` in it is zero.

## Caveat on the link inventory

The "19% of store links were wrong" figure (154 of 809 across all four repos) is a **timestamped snapshot, not an upper bound** — measured by a read-only production query, and it decays from the next publish click onward.

Known and accepted: every module in this repo is currently unpublished, so the 57 suffixed links resolve (revealing unpublished modules) and `to_backend_theme`'s bare link 404s. That is the measured, deliberate outcome of the `Hidden` rule, not a defect. The real gate is `odoo.module.version.website_published`, a runtime-mutable field a static manifest cannot encode — so the suffix is correct for a module's state at release time and no longer.
