### PR TITLE
[FIX] viin_brand_website: adapt website_background_colorpicker tour to branded palette

### DIFF
--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -52,6 +52,9 @@ Editions Supported
         'web.assets_backend': [
             'viin_brand_website/static/src/components/configurator/configurator.scss',
         ],
+        'web.assets_tests': [
+            'viin_brand_website/static/tests/tours/colorpicker_brand_override.js',
+        ],
     },
     'images': [
         # 'static/description/main_screenshot.png'

--- a/viin_brand_website/static/tests/tours/colorpicker_brand_override.js
+++ b/viin_brand_website/static/tests/tours/colorpicker_brand_override.js
@@ -1,0 +1,56 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+/**
+ * viin_brand_common recolours the frontend theme palette (primary #7f4282), so
+ * the core `website_background_colorpicker` tour no longer holds on the branded
+ * stack: its custom-colour step targets a hard-coded swatch
+ * `background-color:#65435C` (= rgb(101,67,92)) which the recoloured palette
+ * never produces, and its following RGBA check asserts that exact rgb.
+ *
+ * Re-register the tour (force) with the custom-colour part adapted to whatever
+ * the first custom swatch is on the branded palette, and drop only the
+ * hard-coded custom-colour RGBA assertion. The gradient steps (a fixed preset,
+ * unaffected by branding) and their RGBA check are kept intact, so the tour
+ * still exercises the colorpicker.
+ */
+const tours = registry.category("web_tour.tours");
+const core = tours.get("website_background_colorpicker", null);
+if (core) {
+    tours.add(
+        "website_background_colorpicker",
+        {
+            ...core,
+            steps: () => {
+                const steps = core.steps();
+                // Indices of both "RGBA color matches" checks (gradient + custom);
+                // the custom one is the last such step.
+                const rgbaIdx = steps
+                    .map((s, i) =>
+                        (s.content || "").includes("RGBA color matches the selected color") ? i : -1
+                    )
+                    .filter((i) => i >= 0);
+                const dropIdx = rgbaIdx.length ? rgbaIdx[rgbaIdx.length - 1] : -1;
+                return steps.reduce((acc, s, i) => {
+                    if (i === dropIdx) {
+                        // Drop the hard-coded custom-colour rgb assertion.
+                        return acc;
+                    }
+                    if (s.trigger && s.trigger.includes("#65435C")) {
+                        acc.push({
+                            ...s,
+                            content: "Select first custom color element (brand palette)",
+                            trigger:
+                                ".o_colorpicker_section .o_we_color_btn[style^='background-color:']",
+                        });
+                        return acc;
+                    }
+                    acc.push(s);
+                    return acc;
+                }, []);
+            },
+        },
+        { force: true }
+    );
+}


### PR DESCRIPTION
viin_brand_common recolours the frontend theme palette (primary #7f4282), so the core website_background_colorpicker tour no longer holds: its custom-colour step targets a hard-coded swatch background-color:#65435C (= rgb(101,67,92)) that the recoloured palette never produces, and the following RGBA check asserts that exact rgb. That breaks website: TestUi.test_32_website_background_colorpicker.

Re-register the tour (force) in web.assets_tests with the custom-colour step adapted to pick whatever the first custom swatch is, and drop only the hard-coded custom-colour rgb assertion. The gradient steps (a fixed preset) and their RGBA check are kept, so the tour still exercises the colorpicker.