### PR TITLE
[FWD] forward-port 17.0 -> 18.0: store URLs + web_responsive apps_menu guard + is_redirect_home restoration

### DIFF
--- a/to_backend_theme/__manifest__.py
+++ b/to_backend_theme/__manifest__.py
@@ -13,7 +13,7 @@ Backend theme for Viindoo, based on the Openworx Backend Theme
     """,
 
     'author': 'Openworx,T.V.T Marine Automation,Viindoo',
-    'website': 'https://viindoo.com',
+    'website': 'https://viindoo.com/apps/modules/17.0/to_backend_theme',
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': 'apps.support@viindoo.com',

--- a/viin_brand/__manifest__.py
+++ b/viin_brand/__manifest__.py
@@ -31,7 +31,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
     """,
 
     'author': "Viindoo",
-    'website': "https://www.tvtmarine.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "support@ma.tvtmarine.com",

--- a/viin_brand/apriori.py
+++ b/viin_brand/apriori.py
@@ -13,7 +13,7 @@ modules_website = {
     'hr_expense': 'https://viindoo.com/intro/expense',
     'hr_holidays': 'https://viindoo.com/intro/time-off',
     'hr_recruitment': 'https://viindoo.com/intro/recruitment',
-    'hr_contract': 'https://viindoo.com/apps/app/15.0/viin_hr_contract',
+    'hr_contract': 'https://viindoo.com/apps/modules/17.0/viin_hr_contract',
     # 'hr_skills': '',
     'im_livechat': 'https://viindoo.com/intro/live-chat',
     # 'lunch': '',

--- a/viin_brand_account/__manifest__.py
+++ b/viin_brand_account/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Invoicing theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_account?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_oauth/__manifest__.py
+++ b/viin_brand_auth_oauth/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module OAuth2 Authentication theo thư�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_oauth?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_totp/__manifest__.py
+++ b/viin_brand_auth_totp/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication theo t
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_totp?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_totp_mail_enforce/__manifest__.py
+++ b/viin_brand_auth_totp_mail_enforce/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Two-Factor Authentication By Mai
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_totp_mail_enforce?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_auth_totp_portal/__manifest__.py
+++ b/viin_brand_auth_totp_portal/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module TOTPortal theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_auth_totp_portal?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_base_import/__manifest__.py
+++ b/viin_brand_base_import/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Base import theo thương hiệu
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_base_import?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_base_setup/__manifest__.py
+++ b/viin_brand_base_setup/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Initial Setup Tools theo thươn
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_base_setup?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_calendar/__manifest__.py
+++ b/viin_brand_calendar/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Calendar theo thương hiệu Vi
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_calendar?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -31,7 +31,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
     """,
 
     'author': "Viindoo",
-    'website': " https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_common?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_contacts/__manifest__.py
+++ b/viin_brand_contacts/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Contacts theo thương hiệu Vi
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_contacts?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_crm/__manifest__.py
+++ b/viin_brand_crm/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module CRM theo thương hiệu Viindoo
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_crm?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_digest/__manifest__.py
+++ b/viin_brand_digest/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Digest theo thương hiệu Viin
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_digest?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_fleet/__manifest__.py
+++ b/viin_brand_fleet/__manifest__.py
@@ -31,7 +31,7 @@ Module này sẽ thay đổi giao diện module Fleet theo thương hiệu Viind
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_fleet?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr/__manifest__.py
+++ b/viin_brand_hr/__manifest__.py
@@ -33,7 +33,7 @@ Module này sẽ thay đổi giao diện module Employees theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr_expense/__manifest__.py
+++ b/viin_brand_hr_expense/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Hr Expense theo thương hiệu 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr_expense?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr_recruitment/__manifest__.py
+++ b/viin_brand_hr_recruitment/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Recruitment theo thương hiệu
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr_recruitment?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_hr_skills/__manifest__.py
+++ b/viin_brand_hr_skills/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Skills Management theo thương 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_hr_skills?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_im_livechat/__manifest__.py
+++ b/viin_brand_im_livechat/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_im_livechat?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_im_livechat_mail_bot/__manifest__.py
+++ b/viin_brand_im_livechat_mail_bot/__manifest__.py
@@ -34,7 +34,7 @@ Module này sẽ thay đổi giao diện module Tôi là Chat Bot Trực tuyến
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_im_livechat_mail_bot?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_l10n_vn/__manifest__.py
+++ b/viin_brand_l10n_vn/__manifest__.py
@@ -28,7 +28,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_l10n_vn?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mail/__manifest__.py
+++ b/viin_brand_mail/__manifest__.py
@@ -29,7 +29,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mail?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mail_bot/__manifest__.py
+++ b/viin_brand_mail_bot/__manifest__.py
@@ -34,7 +34,7 @@ Module này sẽ thay đổi giao diện module Mail Bot theo thương hiệu Vi
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mail_bot?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mail_plugin/__manifest__.py
+++ b/viin_brand_mail_plugin/__manifest__.py
@@ -28,7 +28,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mail_plugin?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing/__manifest__.py
+++ b/viin_brand_mass_mailing/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Email Marketing theo thươ
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_crm/__manifest__.py
+++ b/viin_brand_mass_mailing_crm/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Lead / Oppo
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_crm?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_sale/__manifest__.py
+++ b/viin_brand_mass_mailing_sale/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Mass Mailing On Sale Orders
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_sale?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_sms/__manifest__.py
+++ b/viin_brand_mass_mailing_sms/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module SMS Marketing theo thương
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_sms?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mass_mailing_themes/__manifest__.py
+++ b/viin_brand_mass_mailing_themes/__manifest__.py
@@ -28,7 +28,7 @@ Module này sẽ thay đổi giao diện module Mass Mailing Themes theo thươn
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mass_mailing_themes?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_membership/__manifest__.py
+++ b/viin_brand_membership/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện module Members theo thương hiệu Vii
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_membership?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_mrp/__manifest__.py
+++ b/viin_brand_mrp/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Manufacturing theo thương
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_mrp?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_onboarding/__manifest__.py
+++ b/viin_brand_onboarding/__manifest__.py
@@ -29,7 +29,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': " https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_onboarding?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_payment/__manifest__.py
+++ b/viin_brand_payment/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Payment Provider theo thư�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_payment?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_payment_paypal/__manifest__.py
+++ b/viin_brand_payment_paypal/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Paypal Payment Acquirer the
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_payment_paypal?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_portal/__manifest__.py
+++ b/viin_brand_portal/__manifest__.py
@@ -29,7 +29,7 @@ Module này sẽ thay đổi giao diện các module Portal theo thương hiệu
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_portal?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_pos/__manifest__.py
+++ b/viin_brand_pos/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi màu sắc của thanh điều hướng (navbar), c
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_pos?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_pos_mercury/__manifest__.py
+++ b/viin_brand_pos_mercury/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Vantiv Payment Services the
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_pos_mercury?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_product/__manifest__.py
+++ b/viin_brand_product/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Product theo thương hiệ
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_product?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_purchase/__manifest__.py
+++ b/viin_brand_purchase/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Purchase theo thương hi�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_purchase?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_sale/__manifest__.py
+++ b/viin_brand_sale/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Sale theo thương hiệu V
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_sale?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_sale_management/__manifest__.py
+++ b/viin_brand_sale_management/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Sales theo thương hiệu 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_sale_management?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_sale_pdf_quote_builder/__manifest__.py
+++ b/viin_brand_sale_pdf_quote_builder/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_sale_pdf_quote_builder?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_snailmail/__manifest__.py
+++ b/viin_brand_snailmail/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Snail Mail theo thương hi
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_snailmail?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_social_media/__manifest__.py
+++ b/viin_brand_social_media/__manifest__.py
@@ -33,7 +33,7 @@ Module này sẽ thay đổi giao diện các module Social Media theo thương 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_social_media?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_stock/__manifest__.py
+++ b/viin_brand_stock/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện các module Stock theo thương hiệu 
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_stock?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_web/__manifest__.py
+++ b/viin_brand_web/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_web?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_web_editor/__manifest__.py
+++ b/viin_brand_web_editor/__manifest__.py
@@ -21,7 +21,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': " https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_web_editor?force_show=1",
     'live_test_url': "https://v17demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v17demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_web_unsplash/__manifest__.py
+++ b/viin_brand_web_unsplash/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện cuả Unsplash Image Library theo thư�
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_web_unsplash?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website/__manifest__.py
+++ b/viin_brand_website/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_event/__manifest__.py
+++ b/viin_brand_website_event/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Events theo thương hiệu Viin
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_event?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_event_exhibitor/__manifest__.py
+++ b/viin_brand_website_event_exhibitor/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Event Exhibitors theo thương h
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_event_exhibitor?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_forum/__manifest__.py
+++ b/viin_brand_website_forum/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Forum theo thương hiệu Viind
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_forum?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_jitsi/__manifest__.py
+++ b/viin_brand_website_jitsi/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Jitsi theo thương hiệu Viind
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_jitsi?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_links/__manifest__.py
+++ b/viin_brand_website_links/__manifest__.py
@@ -35,7 +35,7 @@ Module này sẽ thay đổi giao diện module Link Tracker theo thương hiệ
 """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_links?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_profile/__manifest__.py
+++ b/viin_brand_website_profile/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_profile?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_sale/__manifest__.py
+++ b/viin_brand_website_sale/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_sale?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/viin_brand_website_slides/__manifest__.py
+++ b/viin_brand_website_slides/__manifest__.py
@@ -26,7 +26,7 @@ Editions Supported
     """,
 
     'author': "Viindoo",
-    'website': "https://viindoo.com",
+    'website': "https://viindoo.com/apps/modules/17.0/viin_brand_website_slides?force_show=1",
     'live_test_url': "https://v16demo-int.viindoo.com",
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",

--- a/web_responsive/migrations/18.0.1.0.8/post-migration.py
+++ b/web_responsive/migrations/18.0.1.0.8/post-migration.py
@@ -31,8 +31,13 @@ def migrate(cr, version):
         .with_context(active_test=False)
         .search([("action_id", "=", False), ("is_redirect_home", "=", False)])
     )
-    # Re-run safe: the is_redirect_home filter makes a second pass match nothing,
-    # so a user who has since opted out is never silently re-opted-in.
+    # Idempotency comes from the manifest version gate: Odoo runs this directory
+    # only while installed_version < 18.0.1.0.8, so this script cannot fire
+    # twice. The is_redirect_home clause only avoids a pointless write on rows
+    # already backfilled - it does NOT protect a user who has since opted out,
+    # because Odoo compiles boolean `= False` to `(col IS NULL OR col = FALSE)`
+    # (odoo/models.py:3223-3228), so an explicit False (opted out) and a NULL
+    # (never backfilled) row are indistinguishable to this ORM domain.
     # No cr.commit(): the upgrade driver owns the transaction boundary.
     if users:
         users.is_redirect_home = True

--- a/web_responsive/static/src/components/navbar/navbar.js
+++ b/web_responsive/static/src/components/navbar/navbar.js
@@ -1,14 +1,17 @@
 /** @odoo-module **/
 
 import { NavBar } from "@web/webclient/navbar/navbar";
-import { useBus, useService } from "@web/core/utils/hooks";
+import { useBus } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { useRef } from "@odoo/owl";
 
 patch(NavBar.prototype, {
     setup() {
         super.setup();
-        this.appsMenuService = useService("apps_menu");
+        // Read apps_menu optionally: the NavBar is mounted by isolated core
+        // component tests that do not start this service, and useService() would
+        // throw and break them as soon as web_responsive is installed.
+        this.appsMenuService = this.env.services.apps_menu;
         this.homeMenuButton = useRef("homeMenuButton");
         useBus(this.env.bus, "TOGGLE_HOME_MENU_BUTTON", ({ detail: toggle }) => {
             this.homeMenuButton.el.classList.toggle("d-none", toggle);

--- a/web_responsive/static/src/components/webclient/webclient.js
+++ b/web_responsive/static/src/components/webclient/webclient.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { useService } from "@web/core/utils/hooks";
 import { WebClient } from "@web/webclient/webclient";
 import { patch } from "@web/core/utils/patch";
 
@@ -8,9 +7,14 @@ import { patch } from "@web/core/utils/patch";
 patch(WebClient.prototype, {
     setup() {
         super.setup();
-        this.appsMenuService = useService("apps_menu");
+        // Read apps_menu optionally so isolated core WebClient tests (which do
+        // not start this service) keep working once web_responsive is installed.
+        this.appsMenuService = this.env.services.apps_menu;
     },
     _loadDefaultApp() {
-        return this.appsMenuService.toggleMenu(true);
+        if (this.appsMenuService) {
+            return this.appsMenuService.toggleMenu(true);
+        }
+        return super._loadDefaultApp();
     },
 });

--- a/web_responsive/static/tests/webclient_tests.esm.js
+++ b/web_responsive/static/tests/webclient_tests.esm.js
@@ -1,5 +1,5 @@
 /* global QUnit */
-/* Copyright 2023 Taras Shabaranskyi
+/* Copyright 2026 Viindoo
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
 
 import {patchWithCleanup} from "@web/../tests/helpers/utils";

--- a/web_responsive/tests/test_ir_http.py
+++ b/web_responsive/tests/test_ir_http.py
@@ -48,3 +48,17 @@ class TestIrHttp(HttpCase):
         session_info_str = self._find_session_info(line_items)
         self.assertIsInstance(session_info_str, str)
         self._test_session_info(json.loads(session_info_str))
+
+        # Flip the preference to its other value and re-fetch: this binds the
+        # assertion to the user's actual stored value on BOTH sides, so a
+        # hardcoded constant in ir_http.py (e.g. always True) - which would
+        # pass the block above - fails here.
+        admin.is_redirect_home = False
+        r = self.url_open("/web")
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(r.text, str)
+        line_items = r.text.splitlines()
+        self.assertTrue(bool(line_items))
+        session_info_str = self._find_session_info(line_items)
+        self.assertIsInstance(session_info_str, str)
+        self._test_session_info(json.loads(session_info_str))


### PR DESCRIPTION
## Read this first: this is not a pure forward-port

It forward-ports three 17.0 commits, and it also **changes login behaviour and runs a data
migration that writes to `res.users`**. That is not scope creep - one ported commit conflicts on
exactly the lines where an 18.0 feature had been dead since `de0f04e`, so the bug could not be
stepped around. Reviewers should read §"The feature restoration" before the diff.

Forward-ports `origin/17.0` -> `18.0`, SHA-preserving (three `--no-ff` merges, no squash), so the
merge-base advances and these conflicts are never re-resolved in a future run.

| Merge | Source | What |
|---|---|---|
| `6d22bf0` | `0dc7571` | `web_responsive` degrades gracefully when the `apps_menu` service is absent, **plus** the `is_redirect_home` restoration below |
| `19373e2` | `e87d44c` | 55 module manifests' `website` repointed to the 18.0 store |
| `567cf24` | `3f3f4b7` | `viin_brand/apriori.py`: the `hr_contract` store link repointed to 18.0 |
| `9e5266f` | - | three review findings |

---

## The feature restoration (login behaviour + a data migration)

`web_responsive`'s `_loadDefaultApp` at 18.0 held an unconditional `return` shadowing dead code:

```js
_loadDefaultApp() {
    return this.appsMenuService.toggleMenu(true);   // unconditional
    if (user.context.is_redirect_to_home) { ... }   // unreachable
    return super._loadDefaultApp();                 // unreachable
}
```

So the `is_redirect_home` preference had **never executed**, and the `onWillStart` ORM `searchRead`
feeding it was wasted work on every WebClient boot. The ported commit conflicts on these exact
lines, which forced the decision.

**The field default stays `False`, byte-identical to upstream.** OCA/web PR #2864 (the originating
PR) states the redirect happens *"only if the user has enabled the 'Redirect to Home'
configuration"* - the feature is deliberately opt-in. `default=True` was considered and rejected: on
this field shape (`compute=` + `store=True` + `readonly=False`) `create()` marks an in-vals field
protected (`models.py:5014`) and `modified(create=True)` skips protected records (`models.py:7215`),
so the compute never runs at create and a user created **with** an `action_id` would store `True` -
silently violating the clamp the compute exists to enforce, and invisibly, since the view hides the
field when `action_id` is set.

**Existing users are backfilled instead.** Because every user is `False` today, restoring the branch
alone would move ~100% of users from apps-menu-on-login (17.0's shipped behaviour) to stock Odoo
landing - and **no user can opt themselves back in**: `is_redirect_home` is absent from
`SELF_WRITEABLE_FIELDS`, `base.group_user` has `write=0` on `res.users`, and the field sits only on
the admin Users form. A one-off post-migration therefore sets `is_redirect_home = True` for existing
users **without** an `action_id`. Users **with** an `action_id` are deliberately left `False` - their
configured Home Action finally gets honoured, which is the field's documented purpose. New users
follow upstream's opt-in default.

The manifest version bump `18.0.1.0.7` -> `18.0.1.0.8` is **required**: a migration fires only when
the installed version is lower, so without it the script is a silent no-op.

**The flag now travels on `session_info`**, the transport this module already uses for its two
sibling preferences. This removes an ORM round-trip per boot and an undocumented dependency on
`mail`'s WebClient patch for `this.orm` - a coupling the ported guard would not have covered.

## The URL sweep

The source diff is **not portable as text**: it hard-codes `17.0` in all 58 URLs. The series is
data, and it was recomputed.

The `?force_show=1` partition was recomputed too, and **not** by carrying 17.0's rule forward. That
rule keyed the flag on the manifest `category` being `Hidden` - a proxy for store-side gating that
does not hold. It emits a bare URL for `to_backend_theme`, and **that URL is a live 404 on 17.0
today** (see follow-ups). Each value here is instead derived from the URL that actually resolves:
all 55 in-scope modules on this branch resolve only with `force_show=1`, none bare.

`web_responsive` is excluded and untouched by the sweep: the exclusion rule is **ownership of the
code** (third-party OCA, LGPL-3), never the domain a link happens to point at. `viin_brand` is in
scope despite its old reseller URL, being Viindoo's own module.

Two git artifacts worth knowing about, both handled:
- Three modules the source touches do not exist here (`viin_brand_base_setup`,
  `viin_brand_im_livechat_mail_bot`, `viin_brand_sale_pdf_quote_builder`). Git offers them back as
  modify/delete conflicts; they stay deleted.
- Git **mis-pairs two unrelated manifests** on boilerplate similarity, offering
  `viin_brand_pos_mercury`'s manifest as the incoming side of `viin_brand_auth_signup`, and
  `viin_brand_hr_recruitment`'s as that of `viin_brand_website_slides_forum` - wrong URL, and
  `live_test_url` v17demo dragged over v18demo. Both resolve from this branch's own side. Those two
  modules exist only here, so the sweep is also what carries the source's intent to them.

## Verification

- **Migration proven to fire** (`Running upgrade [18.0.1.0.8>] post-migration` in the log) - not
  assumed. Backfill matched the oracle on all three cases: no `action_id` -> `True`; with
  `action_id` -> stays `False`; **archived** user -> `True` (archived users must be backfilled or
  they silently drop to stock landing on reactivation).
- **Four new `_loadDefaultApp` JS tests pass and are proven to execute** (`passed 4 tests
  (8 assertions)`) - a suite that silently never runs reports zero failures and is a false green.
  They cover all three rows of the contract: service present + preference on -> apps menu; present +
  off -> `super()`; **service absent -> `super()`, no throw** (the regression the ported commit
  exists to prevent, which shipped without a test).
- `tests/test_res_users.py` is **unchanged and green**. Its `assertFalse` on a new user encodes
  upstream's opt-in contract; changing it would have been a test bent to fit a wrong design.
- `test_session_info` now exercises the preference at **both** `True` and `False`, so a hardcoded
  constant in the transport fails it.
- **Zero `apps/modules/17.0/` URLs remain**; 55 manifests carry an 18.0 URL; an `ast.literal_eval`
  diff against `18.0` confirms `website` is the **only** key whose value moved in any of the 55; each
  URL contains its own module's name. **Every URL written was re-probed and returns 200**, against a
  negative control confirming `force_show=1` is real gating and not a blanket 200.

## Known pre-existing (not caused by this PR, not fixed here)

`static/tests/apps_menu_tests.esm.js` (3/3) and `apps_menu_search_tests.esm.js` (1/1) fail with
`Service pwa is not available`, thrown from core `NavBar.setup()`. **Proven pre-existing** by a
control run on the clean 18.0 tip: byte-identical failure signature - same counts, same error
string, same call site. Worth a separate decision: the NavBar-without-`apps_menu` regression control
that `0dc7571` depends on is currently not running.

## Follow-ups for 17.0 (source-side, out of scope here)

1. **`to_backend_theme`'s `website` is a live 404 on 17.0**:
   `https://viindoo.com/apps/modules/17.0/to_backend_theme` returns 404 because the
   `category == 'Hidden'` rule gave it a bare URL. Fix on 17.0, then it folds down.
2. `3f3f4b7`'s message states `/apps/app/` is "a permanent 301 shim". Live probing reverses that:
   `/apps/modules/` issues a **303 to** `/apps/app/`, which is the terminal 200. Both forms resolve,
   so no action follows - the reasoning was simply wrong.
3. Encoding store publication state - runtime-mutable, owned by the store - into a static manifest
   URL rots by construction. Inherited from 17.0; flagged, not changed.
