### PR TITLE
[FIX] viin_brand_pos: guard company service in POS Navbar favicon patch

### DIFF
--- a/viin_brand_pos/static/src/app/navbar/navbar.js
+++ b/viin_brand_pos/static/src/app/navbar/navbar.js
@@ -10,7 +10,14 @@ patch(Navbar.prototype, {
     setup() {
         super.setup();
         // copy from to_base
-        const favicon = `/web/image/res.company/${this.env.services.company.currentCompany.id}/favicon`;
+        // The company service is not registered in the bare POS QUnit test env
+        // (point_of_sale.tests.test_js "mount the Chrome"), so guard it: without a
+        // current company there is no branded favicon to set, just skip.
+        const currentCompany = this.env.services.company?.currentCompany;
+        if (!currentCompany) {
+            return;
+        }
+        const favicon = `/web/image/res.company/${currentCompany.id}/favicon`;
         const icons = document.querySelectorAll("link[rel*='icon']");
         for (const icon of icons) {
             if (icon.rel != "apple-touch-icon") {


### PR DESCRIPTION
The POS Navbar patch read this.env.services.company.currentCompany.id unconditionally in setup() to set the branded favicon. The company service is not registered in the bare point_of_sale QUnit test env, so this.env.services.company was undefined and .currentCompany threw "Cannot read properties of undefined (reading 'currentCompany')" in Navbar.setup -> the whole POS Chrome mount failed, failing point_of_sale:WebSuite.test_pos_js ("mount the Chrome").

Optional-chain the service and bail out when there is no current company (no branded favicon to set). Real POS is unaffected.

Verified: point_of_sale:WebSuite.test_pos_js passes (0 failed) on a focused point_of_sale+viin_brand_pos install with the guard.