### PR TITLE
[FIX] web_responsive: keep upstream "Action" statusbar toggler on mobile

### DIFF
--- a/web_responsive/static/src/components/chatter/chatter.xml
+++ b/web_responsive/static/src/components/chatter/chatter.xml
@@ -46,6 +46,7 @@
                     'btn-secondary': state.composerType !== 'note',
                     'my-2': !props.compactHeight
                 }"
+                t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId"
                 data-hotkey="shift+m"
                 t-on-click="() => this.toggleComposer('note')"
             >

--- a/web_responsive/static/src/views/form/status_bar_buttons.xml
+++ b/web_responsive/static/src/views/form/status_bar_buttons.xml
@@ -13,12 +13,13 @@
         <xpath expr="//Dropdown" position="attributes">
             <attribute name="hotkey">'shift+a'</attribute>
         </xpath>
-        <xpath expr="//t[@t-set-slot='toggler']" position="replace">
-            <t t-set-slot="toggler">
-                <i class="fa fa-sliders me-1 me-sm-2" />
-                <span class="d-none d-sm-inline">Action</span>
-            </t>
-        </xpath>
+        <!-- Do NOT replace the toggler with an icon-only variant: upstream
+             Odoo (CE and EE) keeps the plain "Action" text toggler on mobile.
+             The icon-only toggler made .o_statusbar_buttons narrower than
+             core, which gave .o_statusbar_status enough room to render inline
+             arrow pills instead of collapsing into the current-stage dropdown
+             — breaking core mobile tours (test_main_flows main_flow_tour
+             waits for .o_statusbar_status .dropdown-toggle). -->
     </t>
 
 </templates>


### PR DESCRIPTION
Trước khi sửa (bên trái), sau khi sửa (bên phải)

<img width="822" height="235" alt="Screenshot from 2026-07-17 15-52-45" src="https://github.com/user-attachments/assets/921777b4-d130-4a2c-bb21-2dd4ec9cbfbd" />
