### PR TITLE
[FIX] viin_brand_common: keep statusbar arrows compact so 4 stages fit on mobile

### DIFF
--- a/viin_brand_common/static/src/views/fields/statusbar/statusbar_field.scss
+++ b/viin_brand_common/static/src/views/fields/statusbar/statusbar_field.scss
@@ -1,5 +1,17 @@
 .o_field_statusbar {
     > .o_statusbar_status {
+        // Keep the status-flow arrows at the framework's compact control size.
+        // The brand's larger $o-font-size-base (15px vs core's 14px) widens each
+        // arrow enough that a 4-stage statusbar no longer fits on one row on
+        // small screens, so one arrow wraps into the overflow dropdown - breaking
+        // core's mobile web StatusBarField tests, which assert every stage renders
+        // as an inline arrow (and, via adjustVisibleItems, that no false wrap
+        // collapses them). This only trims the arrow chrome; stage labels stay
+        // legible.
+        > .o_arrow_button {
+            font-size: $o-font-size-base-small;
+        }
+
         > .o_arrow_button:not(.d-none) {
             &.o_arrow_button_current:disabled, &:active:not(.o_first) {
 				background-color: $brand-primary-super-light;


### PR DESCRIPTION

<img width="752" height="768" alt="statusbar_compare" src="https://github.com/user-attachments/assets/c3b489d5-7da4-4ca5-9d79-0de9b60265f0" />


The brand raises $o-font-size-base to 15px (core default is 14px). That extra width on the status-flow arrows is enough that a 4-stage statusbar no longer fits one row on small screens: adjustVisibleItems detects the wrap and folds one arrow into the overflow dropdown. Core's mobile web StatusBarField QUnit tests assert every stage renders as an inline arrow (4 visible, a single "..." toggle, one disabled dropdown item), so they failed 3/... under the branded assets while passing on clean CE.

Root-caused on v17_full by instrumenting core areItemsWrapping(): branded arrows measured 65px wide / 34.5px tall vs clean CE's 50-61px / 33px, tipping 4 arrows over the container width.

Scope the arrows to $o-font-size-base-small (13px) - the framework's compact control size - so they match core's geometry and all four stages stay inline.
Only the arrow chrome shrinks; stage labels remain legible.

Verified on v17_full: web MobileWebSuite.test_mobile_js 0 failed (the three StatusBarField "small devices" / "extra small screens" / "clickable ... on mobile" cases now pass).