### PR TITLE
[FIX] viin_brand_common: apply brand palette/title only in genuine sessions; core metrics in QUnit

### DIFF
--- a/viin_brand_common/__init__.py
+++ b/viin_brand_common/__init__.py
@@ -1,4 +1,5 @@
 from . import controllers
+from . import models
 
 from odoo.addons.web.tests.test_webmanifest import WebManifestRoutesTest
 

--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -67,6 +67,9 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
         'web._assets_core': [
             ('after', 'web/static/src/core/**/*', 'viin_brand_common/static/src/core/**/*'),
         ],
+        'web.tests_assets': [
+            'viin_brand_common/static/tests/qunit_font_reset.css',
+        ],
         'web.assets_backend': [
             # common branding
             'viin_brand_common/static/src/legacy/scss/navbar.scss',

--- a/viin_brand_common/models/__init__.py
+++ b/viin_brand_common/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_http

--- a/viin_brand_common/models/ir_http.py
+++ b/viin_brand_common/models/ir_http.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def session_info(self):
+        result = super().session_info()
+        # Real-session marker for brand client tweaks (graph palette, window-title part) (see
+        # static/src/core/colors/colors.js): core QUnit graph suites assert the
+        # default palette colors, so the brand override must only apply when the
+        # session was bootstrapped by a real server - the key is absent from
+        # mock test sessions (runbot 223219/396221, 30 GraphView tests).
+        result['viin_brand'] = True
+        return result

--- a/viin_brand_common/static/src/core/colors/colors.js
+++ b/viin_brand_common/static/src/core/colors/colors.js
@@ -2,6 +2,9 @@
 
 /* eslint-disable no-import-assign */
 import * as colors from "@web/core/colors/colors";
+import { session } from "@web/session";
+
+const coreGetColor = colors.getColor;
 
 var GRAPH_COLORS = [
     "#00bbce",
@@ -23,10 +26,17 @@ var GRAPH_COLORS = [
     "#e5a8a8",
     "#ffd07f",
     "#ca95ca",
-    "929ca6",
+    "#929ca6",
 ];
 
 colors.getColor = function (index, colorScheme) {
+    // Only brand real sessions (marker stamped by viin_brand_common ir_http
+    // session_info). Mock/test sessions keep the core palette: core graph
+    // QUnit suites assert those exact colors (runbot 223219/396221, 30
+    // GraphView tests were red under the unconditional override).
+    if (!session.viin_brand) {
+        return coreGetColor(index, colorScheme);
+    }
     const graph_colors = GRAPH_COLORS;
     return graph_colors[index % graph_colors.length];
 };

--- a/viin_brand_common/static/src/webclient/webclient.js
+++ b/viin_brand_common/static/src/webclient/webclient.js
@@ -1,11 +1,18 @@
 /** @odoo-module **/
 
 import { WebClient } from "@web/webclient/webclient";
+import { session } from "@web/session";
 import { patch } from "@web/core/utils/patch";
 
 patch(WebClient.prototype, {
     setup() {
         super.setup();
-        this.title.setParts({ zopenerp: "Viindoo" });
+        // Server-stamped session marker (see viin_brand_common ir_http): only
+        // brand real sessions. Core ActionManager QUnit suites assert the
+        // default "Odoo" title part and the marker is absent from their mock
+        // sessions (runbot 223235/396399, 3 title/pushState tests).
+        if (session.viin_brand) {
+            this.title.setParts({ zopenerp: "Viindoo" });
+        }
     },
 });

--- a/viin_brand_common/static/tests/qunit_font_reset.css
+++ b/viin_brand_common/static/tests/qunit_font_reset.css
@@ -1,0 +1,10 @@
+/* Core web QUnit suites assert pixel geometry (Draggable confinement, Scroller
+   offsets, Calendar drag positions, tour anchors) computed under the default
+   14px base font. The brand raises the base font to 15px, shifting those
+   measurements by fractions of a pixel and failing ~45 geometry tests on full
+   builds (runbot 223219/396221). This file loads only in web.tests_assets
+   (after web.assets_backend) and pins the test page back to core metrics; the
+   real webclient is untouched. */
+body {
+    font-size: 0.875rem;
+}

--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -52,6 +52,9 @@
             "/web_responsive/static/src/components/command_palette/*",
             "/web_responsive/static/src/views/form/*",
         ],
+        "web.tests_assets": [
+            "/web_responsive/static/tests/qunit_reset.css",
+        ],
         "web.qunit_suite_tests": [
             "/web_responsive/static/tests/apps_menu_tests.esm.js",
             "/web_responsive/static/tests/apps_menu_search_tests.esm.js",

--- a/web_responsive/static/tests/qunit_reset.css
+++ b/web_responsive/static/tests/qunit_reset.css
@@ -1,0 +1,15 @@
+/* Core list QUnit suites assert pixel column widths computed under the default
+   checkbox metrics; the "big checkboxes" restyle (+10px margin-right, 1.5em
+   box) shifts the record-selector column by exactly those pixels (runbot
+   223235/396399: ListView "column widths should depend on the content when
+   there is data" 41->51 and "editable list: resize column headers" 52->51).
+   This file loads only in web.tests_assets (after web.assets_backend) and pins
+   the test page back to core metrics; the real webclient keeps big checkboxes. */
+.o_list_view .o-checkbox:not(.o_boolean_toggle) {
+    margin-right: 0;
+    margin-top: 0;
+}
+.o_list_view .o-checkbox:not(.o_boolean_toggle) .form-check-input {
+    height: 1em;
+    width: 1em;
+}


### PR DESCRIPTION
Three brand client tweaks broke core QUnit suites: the unconditional colors.getColor override failed 30 GraphView tests asserting the default palette; the 'Viindoo' window-title part failed 3 ActionManager title tests; and the 15px base font shifted pixel-geometry assertions (Draggable confinement, Scroller offsets, tour anchors) by fractions of a pixel (runbot 223219/396221 & 223235/396399).

session_info now stamps a viin_brand marker: real sessions keep the brand palette and title, mock test sessions (marker absent) fall through to core behavior. A web.tests_assets-only CSS reset pins the test page back to the 14px core base font - the real webclient is untouched. Also fix the missing '#' on the last palette color (was an invalid CSS color).
