### PR TITLE
[IMP][17.0] viin_brand_website_sale: drop unverifiable "#1" claim from promo

### DIFF
--- a/viin_brand_website_sale/__manifest__.py
+++ b/viin_brand_website_sale/__manifest__.py
@@ -35,7 +35,7 @@ Editions Supported
     # Check https://github.com/Viindoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Hidden',
-    'version': '0.1',
+    'version': '0.2',
 
     # any module necessary for this one to work correctly
     'depends': ['website_sale'],

--- a/viin_brand_website_sale/i18n/vi_VN.po
+++ b/viin_brand_website_sale/i18n/vi_VN.po
@@ -17,8 +17,8 @@ msgstr ""
 
 #. module: viin_brand_website_sale
 #: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion
-msgid "The #1 Open Source eCommerce Software"
-msgstr "Phần mềm Thương mại Điện tử mã nguồn mở số 1"
+msgid "Open Source eCommerce Software"
+msgstr "Phần mềm Thương mại Điện tử mã nguồn mở"
 
 #. module: viin_brand_website_sale
 #: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion

--- a/viin_brand_website_sale/i18n/viin_brand_website_sale.pot
+++ b/viin_brand_website_sale/i18n/viin_brand_website_sale.pot
@@ -17,7 +17,7 @@ msgstr ""
 
 #. module: viin_brand_website_sale
 #: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion
-msgid "The #1 Open Source eCommerce Software"
+msgid "Open Source eCommerce Software"
 msgstr ""
 
 #. module: viin_brand_website_sale

--- a/viin_brand_website_sale/views/templates.xml
+++ b/viin_brand_website_sale/views/templates.xml
@@ -7,8 +7,9 @@
                 position="replace">
                 <t t-call="web.brand_promotion_message">
                     <t t-set="_message">
+                        <!-- Label must not assert a "#1"/superiority ranking (VN advertising law). -->
                         <a target="_blank"
-                            href="https://viindoo.com/intro/ecommerce?utm_source=db&amp;utm_medium=website">The #1 Open Source eCommerce Software</a>
+                            href="https://viindoo.com/intro/ecommerce?utm_source=db&amp;utm_medium=website">Open Source eCommerce Software</a>
                     </t>
                     <t t-set="_utm_medium" t-valuef="website" />
                 </t>


### PR DESCRIPTION
## Mục tiêu

Gỡ cụm khẳng định xếp hạng "#1 / số 1" trong dòng "Powered by" ở footer trang eCommerce (website_sale) của bộ branding Viindoo, nhằm tuân thủ quy định quảng cáo tại Việt Nam.

## Bối cảnh / Lý do

Footer eCommerce đang hiển thị "The #1 Open Source eCommerce Software" (tiếng Việt: "Phần mềm Thương mại Điện tử mã nguồn mở số 1") - một khẳng định "số 1 / dẫn đầu" không kèm tài liệu chứng minh. Luật quảng cáo Việt Nam cấm dùng từ ngữ so sánh tuyệt đối kiểu "số 1", "tốt nhất" khi không có căn cứ chứng minh và có thể bị xử phạt nặng, nên cần loại bỏ cụm này ở cả hai ngôn ngữ.

<img width="2880" height="120" alt="branding-no1-footer-v17-before" src="https://github.com/user-attachments/assets/4d9f69ce-2d27-42a0-a81f-988e5eaef81f" />
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/e532b231-ec74-4b30-91a0-3af7a39d8f3c" />


## Thay đổi

- `views/templates.xml`: nhãn quảng bá "The #1 Open Source eCommerce Software" -> "Open Source eCommerce Software"; thêm comment ngay tại nhãn ghi rõ ràng buộc theo luật quảng cáo VN (chống tái phát).
- `i18n/vi_VN.po` và `i18n/viin_brand_website_sale.pot`: đồng bộ `msgid` theo chuỗi nguồn mới; `msgstr` "... mã nguồn mở số 1" -> "... mã nguồn mở".
- `__manifest__.py`: nâng version `0.1` -> `0.2` để cơ sở dữ liệu đã cài nhận cập nhật view + bản dịch khi `-u`.

## Kiểm thử

- Cài/nâng cấp `viin_brand_website_sale`, mở trang shop (website_sale), kiểm tra dòng "Powered by" ở footer: bản tiếng Anh hiển thị "Open Source eCommerce Software", bản tiếng Việt hiển thị "Phần mềm Thương mại Điện tử mã nguồn mở" - không còn "#1 / số 1".
- Đã rà toàn module: không còn chuỗi "#1"/"số 1" trong nội dung hiển thị (chỉ còn trong comment mã nguồn, không phải nội dung render tới người dùng).

<img width="2880" height="120" alt="branding-no1-footer-v17-after" src="https://github.com/user-attachments/assets/6035d1de-41eb-4f71-9894-1d7c627dc812" />
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/2520edb9-a436-48bb-8850-6d272eca11b4" />


## Ảnh hưởng / Lưu ý

- Chỉ đổi nhãn hiển thị footer eCommerce; không đụng schema, không đụng logic nghiệp vụ.
- Không kèm test tự động vì đây là thay đổi nhãn hiển thị (label-only).
- Ngoài phạm vi PR: manifest đang để `auto_install: ['website_sale']` (hook convention gợi ý `True`) - giữ nguyên để diff tối thiểu trên nhánh stable, có thể dọn ở PR riêng.
