### PR TITLE
[IMP][13.0] viin_brand_website_sale: drop unverifiable "#1" claim from promo

### DIFF
--- a/viin_brand_website_sale/__manifest__.py
+++ b/viin_brand_website_sale/__manifest__.py
@@ -36,7 +36,7 @@ Editions Supported
     # Check https://github.com/tvtma/odoo/blob/13.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Hidden',
-    'version': '0.1',
+    'version': '0.2',
 
     # any module necessary for this one to work correctly
     'depends': ['website_sale'],

--- a/viin_brand_website_sale/i18n/vi_VN.po
+++ b/viin_brand_website_sale/i18n/vi_VN.po
@@ -17,10 +17,5 @@ msgstr ""
 
 #. module: viin_brand_website_sale
 #: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion
-msgid "#1 Open Source eCommerce Software"
-msgstr "Phần mềm Thương mại Điện tử Mã nguồn mở số 1"
-
-#. module: viin_brand_website_sale
-#: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion
-msgid "The"
-msgstr " "
+msgid "Open Source eCommerce Software"
+msgstr "Phần mềm Thương mại Điện tử Mã nguồn mở"

--- a/viin_brand_website_sale/i18n/viin_brand_website_sale.pot
+++ b/viin_brand_website_sale/i18n/viin_brand_website_sale.pot
@@ -17,10 +17,5 @@ msgstr ""
 
 #. module: viin_brand_website_sale
 #: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion
-msgid "#1 Open Source eCommerce Software"
-msgstr ""
-
-#. module: viin_brand_website_sale
-#: model_terms:ir.ui.view,arch_db:viin_brand_website_sale.brand_promotion
-msgid "The"
+msgid "Open Source eCommerce Software"
 msgstr ""

--- a/viin_brand_website_sale/views/templates.xml
+++ b/viin_brand_website_sale/views/templates.xml
@@ -7,9 +7,9 @@
                 position="replace">
                 <t t-call="web.brand_promotion_message">
                     <t t-set="_message">
-                        The
+                        <!-- Label must not assert a "#1"/superiority ranking (VN advertising law). -->
                         <a target="_blank"
-                            href="https://viindoo.com/intro/ecommerce?utm_source=db&amp;utm_medium=website">#1 Open Source eCommerce Software</a>
+                            href="https://viindoo.com/intro/ecommerce?utm_source=db&amp;utm_medium=website">Open Source eCommerce Software</a>
                     </t>
                     <t t-set="_utm_medium" t-valuef="website" />
                 </t>


### PR DESCRIPTION
## Mục tiêu

Gỡ cụm khẳng định xếp hạng "#1 / số 1" trong dòng "Powered by" ở footer trang eCommerce (website_sale) của bộ branding Viindoo trên nhánh **13.0**, để tuân thủ quy định quảng cáo tại Việt Nam. Đối ứng với PR trên 17.0 (Viindoo/branding#659) - nhiều khách hàng SaaS Viindoo vẫn còn instance ở 13.0.

## Bối cảnh / Lý do

Footer eCommerce đang hiển thị "The #1 Open Source eCommerce Software" (tiếng Việt: "Phần mềm Thương mại Điện tử Mã nguồn mở số 1") - một khẳng định "số 1 / dẫn đầu" không kèm tài liệu chứng minh. Luật quảng cáo Việt Nam cấm dùng từ ngữ so sánh tuyệt đối kiểu "số 1", "tốt nhất" khi không có căn cứ chứng minh và có thể bị xử phạt nặng, nên cần loại bỏ cụm này ở cả hai ngôn ngữ.

## Thay đổi

- `views/templates.xml`: gỡ "#1" khỏi nhãn quảng bá VÀ text-node "The" đứng riêng (ở 13.0 "The" nằm ngoài thẻ `<a>`) → nhãn còn "Open Source eCommerce Software"; thêm comment ngay tại nhãn ghi rõ ràng buộc theo luật quảng cáo VN (chống tái phát).
- `i18n/vi_VN.po` và `i18n/viin_brand_website_sale.pot`: đồng bộ `msgid` theo chuỗi nguồn mới, gỡ term `"The"` nay đã mồ côi; `msgstr` "... Mã nguồn mở số 1" -> "... Mã nguồn mở".
- `__manifest__.py`: nâng version `0.1` -> `0.2` để cơ sở dữ liệu đã cài nhận cập nhật view + bản dịch khi `-u`.

## Kiểm thử

- Workspace không có Odoo 13 core nên không dựng instance 13.0 local để chụp; xác minh bằng diff nguồn + kiểm chuỗi: không còn "#1"/"số 1" trong nội dung render (chỉ còn trong comment mã nguồn), XML well-formed, `.po`/`.pot` cân `msgid`/`msgstr`. Layout footer ở 13.0 và 17.0 gần như trùng nhau; ảnh footer TRƯỚC/SAU chụp trên instance 17.0 (kèm PR #659) minh hoạ chung cho thay đổi này.
- Trên instance 13.0 thật: cài/nâng cấp `viin_brand_website_sale`, mở trang shop, kiểm dòng "Powered by": EN "Open Source eCommerce Software", VI "Phần mềm Thương mại Điện tử Mã nguồn mở".

## Ảnh hưởng / Lưu ý

- Chỉ đổi nhãn hiển thị footer eCommerce; không đụng schema, không đụng logic nghiệp vụ.
- Không kèm test tự động vì đây là thay đổi nhãn hiển thị (label-only).
- Ngoài phạm vi PR: manifest đang để `auto_install: ['website_sale']` và `website` trỏ URL chung `viindoo.com` (đều pre-existing) - giữ nguyên để diff tối thiểu trên nhánh stable, có thể dọn ở PR riêng.
