### PR TITLE
[FIX] viin_brand_common: anchor web.layout xpaths on //head so core's QUnit guard can run again

### DIFF
--- a/viin_brand_common/__manifest__.py
+++ b/viin_brand_common/__manifest__.py
@@ -36,7 +36,7 @@ Mô đun này thay đổi một vài thông tin dành riêng cho thương hiệu
     'live_test_url_vi_VN': "https://v16demo-vn.viindoo.com",
     'support': "apps.support@viindoo.com",
     'category': 'Hidden',
-    'version': '0.3.1',
+    'version': '0.3.2',
     'depends': ['viin_brand', 'web'],
     'data': [
         'views/ir_module_views.xml',

--- a/viin_brand_common/tests/__init__.py
+++ b/viin_brand_common/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_web_layout
 from . import test_webmanifest

--- a/viin_brand_common/tests/test_web_layout.py
+++ b/viin_brand_common/tests/test_web_layout.py
@@ -1,0 +1,190 @@
+from lxml import etree
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import HttpCase, tagged
+
+# The exact arch core writes onto web.layout in WebSuite._check_only_call
+# (web/tests/test_js.py:104) so it can read the QUnit asset bundles outside a
+# request context. Pinned as a literal on purpose: if core ever changes this
+# stub, the failure must surface loudly here instead of letting the real
+# defect resurface unnoticed.
+WEB_LAYOUT_QUNIT_STUB = (
+    '<t t-name="web.layout">'
+    '<head><meta charset="utf-8"/><t t-esc="head"/></head>'
+    "</t>"
+)
+
+BRAND_TITLE = "Viindoo"
+BRAND_FAVICON = "/viin_brand/static/img/favicon.ico"
+CORE_FAVICON = "/web/static/img/favicon.ico"
+CUSTOM_FAVICON = "/test/custom-favicon.ico"
+
+
+@tagged("-at_install", "post_install")
+class TestWebLayoutBrandDefaults(HttpCase):
+    """
+    The brand defaults viin_brand_common puts on web.layout - title and
+    favicon - are FALLBACKS: they must appear wherever nothing else supplies
+    a value, must never pre-empt a value someone else supplied, and must
+    survive core rewriting web.layout's arch to a stub.
+
+    Viindoo/branding#654: core's WebSuite.test_check_suite replaces
+    web.layout's whole arch_db with a minimal stand-in that has a <head> but
+    no <title> and no <link>. That write fires ir.ui.view's
+    @api.constrains('arch_db') _check_xml, which recombines every EXTENSION
+    of web.layout - viin_brand_common.web_layout included. An xpath anchored
+    on a node the stand-in lacks breaks the recombination, and the test that
+    then errors is precisely the one keeping a stray QUnit.only() from
+    silently disabling the entire JS suite.
+
+    Everything below asserts OBSERVABLE output - rendered HTML, or the
+    recombined arch web.layout actually ends up with - never the arch string
+    of viin_brand_common's own template. The fix for #654 necessarily MOVES
+    the node carrying the defaults, so an assertion on our own arch would
+    lock in one implementation and turn the correct fix into a false alarm.
+    """
+
+    def _brand_title_default_nodes(self, combined_arch):
+        """Return every node in ``combined_arch`` that binds ``title`` to the
+        brand default.
+
+        Deliberately shape-tolerant - it looks for the behavior ("something
+        still binds title to the brand default"), not for one xpath. Two
+        shapes count:
+
+        * a ``t-set`` of ``title`` carrying the brand in its value or text,
+          e.g. ``<t t-set="title" t-value="title or 'Viindoo'"/>``
+        * a ``<title>`` element carrying the brand in an attribute or its
+          text, e.g. ``<title t-esc="title or 'Viindoo'"/>``
+        """
+        found = []
+        for node in combined_arch.iter():
+            if not isinstance(node.tag, str):
+                continue  # comments and processing instructions
+            carries_brand = any(
+                BRAND_TITLE in value
+                for value in list(node.attrib.values()) + [node.text or ""]
+            )
+            if not carries_brand:
+                continue
+            if node.get("t-set") == "title" or etree.QName(node).localname == "title":
+                found.append(node)
+        return found
+
+    def test_brand_title_default_survives_core_qunit_stub_of_web_layout(self):
+        """Core must be able to stub web.layout without the brand being lost.
+
+        Two halves, and both are load-bearing. The write must not raise -
+        while it does, /web:WebSuite.test_check_suite errors on every Viindoo
+        database and its QUnit.only()/QUnit.debug() leak guard is dead. And
+        the brand default must still be there afterwards - otherwise deleting
+        viin_brand_common's web.layout extension would "fix" #654 by throwing
+        away the branding the module exists to provide.
+        """
+        layout = self.env.ref("web.layout")
+        try:
+            layout.write({"arch_db": WEB_LAYOUT_QUNIT_STUB})
+        except ValidationError as exc:
+            self.fail(
+                "web.layout must accept the stub arch core writes in "
+                "WebSuite._check_only_call (web/tests/test_js.py:104); while "
+                "it does not, core's QUnit leak guard is disabled on every "
+                "Viindoo database (Viindoo/branding#654). Raised: %s" % exc
+            )
+
+        combined_arch = etree.fromstring(layout.get_combined_arch())
+        self.assertTrue(
+            self._brand_title_default_nodes(combined_arch),
+            "once core has stubbed web.layout, its combined arch must STILL "
+            "bind title to the '%s' default - dropping the extension is not a "
+            "fix for #654, it is a loss of branding" % BRAND_TITLE,
+        )
+
+    def test_backend_page_falls_back_to_brand_title_and_favicon(self):
+        """With no title and no x_icon supplied, a backend page shows the
+        Viindoo brand, never Odoo's."""
+        self.authenticate("admin", "admin")
+        response = self.url_open("/web")
+        self.assertEqual(response.status_code, 200)
+        document = response.text
+        self.assertEqual(
+            document.count("<title>"),
+            1,
+            "exactly one <title> must render - a second one would mean the "
+            "brand default is emitted alongside another producer instead of "
+            "falling back to it",
+        )
+        self.assertIn(
+            "<title>%s</title>" % BRAND_TITLE,
+            document,
+            "the default backend title must be the brand, not core's 'Odoo'",
+        )
+        self.assertIn(
+            'href="%s"' % BRAND_FAVICON,
+            document,
+            "the default favicon must be the brand one",
+        )
+        self.assertNotIn(
+            CORE_FAVICON,
+            document,
+            "core's own favicon must not reach the rendered page",
+        )
+
+    def test_explicit_title_wins_over_brand_default(self):
+        """A page that supplies its own title keeps it.
+
+        viin_brand_common's own /web/offline page sets <t t-set="title">
+        Offline</t> in its t-call="web.layout" body. This is the assertion
+        that fails if the brand default is ever expressed as an
+        unconditional assignment rather than a fallback.
+        """
+        response = self.url_open("/web/offline")
+        self.assertEqual(response.status_code, 200)
+        document = response.text
+        self.assertEqual(document.count("<title>"), 1)
+        self.assertIn(
+            "<title>Offline</title>",
+            document,
+            "the title the page supplied must survive",
+        )
+        self.assertNotIn(
+            "%s</title>" % BRAND_TITLE,
+            document,
+            "the brand fallback must not overwrite a supplied title",
+        )
+
+    def test_explicit_favicon_wins_over_brand_default(self):
+        """A page that supplies its own x_icon keeps it.
+
+        No shipped route sets x_icon explicitly, so one is injected into the
+        offline page's own t-call body by editing the PARSED tree and writing
+        it back - never a string patch of the arch - and rolled back with the
+        test savepoint. The assertion is on the rendered HTML, not on the arch.
+        """
+        offline_view = self.env.ref("viin_brand_common.webclient_offline")
+        arch = etree.fromstring(offline_view.arch_db)
+        title_nodes = arch.xpath(".//t[@t-set='title']")
+        self.assertTrue(
+            title_nodes,
+            "fixture setup: no <t t-set=\"title\"> found in "
+            "viin_brand_common.webclient_offline - update this fixture if "
+            "that template changed",
+        )
+        x_icon_node = etree.Element("t", {"t-set": "x_icon"})
+        x_icon_node.text = CUSTOM_FAVICON
+        title_nodes[0].addnext(x_icon_node)
+        offline_view.write({"arch_db": etree.tostring(arch, encoding="unicode")})
+
+        response = self.url_open("/web/offline")
+        self.assertEqual(response.status_code, 200)
+        document = response.text
+        self.assertIn(
+            'href="%s"' % CUSTOM_FAVICON,
+            document,
+            "the x_icon the page supplied must survive",
+        )
+        self.assertNotIn(
+            BRAND_FAVICON,
+            document,
+            "the brand fallback must not overwrite a supplied x_icon",
+        )

--- a/viin_brand_common/views/webclient_template.xml
+++ b/viin_brand_common/views/webclient_template.xml
@@ -3,11 +3,11 @@
 <odoo>
 	<template id="web_layout" inherit_id="web.layout"
 		name="Viindoo Web layout">
-		<xpath expr="//title" position="attributes">
-			<attribute name="t-esc">title or 'Viindoo'</attribute>
-		</xpath>
-		<xpath expr="//link[@type='image/x-icon']" position="attributes">
-			<attribute name="t-att-href">x_icon or '/viin_brand/static/img/favicon.ico'</attribute>
+		<!-- Anchored on {head, meta} - the only nodes core's web.layout QUnit stub
+			also has (web/tests/test_js.py) - and last, so real producers still win. -->
+		<xpath expr="//head/meta[last()]" position="after">
+			<t t-set="title" t-value="title or 'Viindoo'"/>
+			<t t-set="x_icon" t-value="x_icon or '/viin_brand/static/img/favicon.ico'"/>
 		</xpath>
 	</template>
 	

--- a/viin_brand_website/tests/__init__.py
+++ b/viin_brand_website/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_website_title_not_preempted

--- a/viin_brand_website/tests/test_website_title_not_preempted.py
+++ b/viin_brand_website/tests/test_website_title_not_preempted.py
@@ -1,0 +1,170 @@
+from lxml import html
+
+from odoo.tests.common import HttpCase, tagged
+
+# viin_brand_common's web.layout brand defaults (Viindoo/branding#654 fix,
+# viin_brand_common/views/webclient_template.xml) are meant to be a
+# last-resort FALLBACK for `title` / `x_icon`. On a `website`-rendered page,
+# website.layout's own producers (per-page title, seo_object, favicon) must
+# always win. Nothing in this repo asserted that until now - the currently
+# open PR #661 (branding fork, head `acc5474`) proved the opposite is easy
+# to break: its `//head position="before"` anchor lands the brand t-set
+# nodes OUTSIDE <head> and BEFORE website.layout's `<t t-if="not title">`
+# guard (website/views/website_templates.xml), so every website page
+# silently collapsed to <title>Viindoo</title> with zero OpenGraph/Twitter
+# meta. This module - the only branding module that legitimately depends on
+# `website` - owns that cross-module contract.
+BRAND_TITLE = "Viindoo"
+BRAND_FAVICON = "/viin_brand/static/img/favicon.ico"
+WEBSITE_NAME = "Test Website"
+
+
+@tagged("-at_install", "post_install")
+class TestWebsiteTitleNotPreempted(HttpCase):
+    """The brand default title/favicon fallback must never pre-empt a value
+    a website-rendered page produces itself.
+
+    All three tests hit the SAME route (`/contactus` - a `website.page`
+    shipped by base `website`, no `website_crm` dependency needed,
+    `website/data/website_data.xml:524-547`) so they exercise exactly the
+    producer chain PR #661 broke: website.layout's `<t t-if="not title">`
+    guard (title + seo_object), its OpenGraph/Twitter meta block, and its
+    unconditional favicon `t-set`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Precondition guard (load-bearing): viin_brand_website deliberately
+        # does NOT depend on viin_brand_common (see __manifest__.py
+        # 'depends': ['website']) - adding that edge for one test would
+        # change the module graph for zero behavioural gain. The edge is
+        # expected to always be satisfied in practice because
+        # viin_brand_common declares `auto_install: ['web']` and every
+        # database with `website` installed also has `web` installed
+        # (`website` depends on `web`). Assert that assumption explicitly
+        # instead of silently relying on it.
+        brand_common = self.env["ir.module.module"].sudo().search([
+            ("name", "=", "viin_brand_common"),
+            ("state", "=", "installed"),
+        ], limit=1)
+        if not brand_common:
+            self.skipTest(
+                "viin_brand_common is not installed on this database - this "
+                "test protects the contract between its web.layout brand "
+                "default and website.layout's own producers, so it is "
+                "meaningless without it. viin_brand_website does not "
+                "depend on viin_brand_common directly; it is expected to "
+                "arrive via viin_brand_common's own auto_install: ['web'] "
+                "since website depends on web. If this fires, that "
+                "assumption no longer holds and needs investigation."
+            )
+
+        self.website = self.env.ref("website.default_website")
+        self.website.write({"name": WEBSITE_NAME})
+
+    def test_website_page_title_is_not_preempted_by_brand_default(self):
+        """AC-W1: a website page's own title must win over the brand
+        default - it must never render as the literal brand fallback.
+
+        Falsifiable against PR #661: under its `//head position="before"`
+        anchor, `title` is already bound to the brand default before
+        website.layout's `<t t-if="not title">` producer runs, so that
+        producer's `not title` is False and it never sets a per-page title.
+        The page renders `<title>Viindoo</title>` instead of the website's
+        own title. This assertion fails loudly under that anchor and passes
+        under the chosen fix (`//head/meta[last()] position="after"`,
+        strictly downstream of website.layout's producer).
+        """
+        response = self.url_open("/contactus")
+        self.assertEqual(response.status_code, 200)
+
+        document = html.fromstring(response.content)
+        titles = document.xpath("//title")
+        self.assertEqual(
+            len(titles), 1,
+            "exactly one <title> must render on a website page",
+        )
+        title_text = titles[0].text_content()
+        self.assertNotEqual(
+            title_text, BRAND_TITLE,
+            "the brand default must not pre-empt website.layout's own "
+            "title producer on a website-rendered page",
+        )
+        self.assertTrue(
+            title_text.endswith(WEBSITE_NAME),
+            "the page title must end with the configured website name "
+            "(%r), got %r" % (WEBSITE_NAME, title_text),
+        )
+
+    def test_website_page_meta_survive_brand_default(self):
+        """AC-W2: OpenGraph/Twitter meta must still be emitted - the
+        assertion that would have caught PR #661's silent SEO loss.
+
+        Falsifiable against PR #661: `seo_object` is assigned ONLY inside
+        the same `<t t-if="not title">` guard as the per-page title
+        (website/views/website_templates.xml). Under #661's anchor that
+        guard is skipped (see the previous test's docstring), so
+        `get_website_meta()` is never called and the page emits NOT ONE
+        OpenGraph or Twitter meta tag - a silent, site-wide SEO and
+        social-sharing regression nothing else in this repo tests. Both
+        xpath queries below return empty lists under that anchor, which is
+        exactly what fails this test.
+        """
+        response = self.url_open("/contactus")
+        self.assertEqual(response.status_code, 200)
+
+        document = html.fromstring(response.content)
+        og_titles = document.xpath('//meta[@property="og:title"]')
+        self.assertTrue(
+            og_titles,
+            'at least one <meta property="og:title"> must render - its '
+            "absence means website.layout's seo_object producer was "
+            "pre-empted (the Viindoo/branding#661 regression)",
+        )
+        self.assertTrue(
+            any(meta.get("content") for meta in og_titles),
+            "the og:title meta must carry real content, not an empty "
+            "placeholder",
+        )
+
+        twitter_cards = document.xpath('//meta[@name="twitter:card"]')
+        self.assertTrue(
+            twitter_cards,
+            'at least one <meta name="twitter:card"> must render - its '
+            "absence means the whole Twitter card block was skipped",
+        )
+
+    def test_website_favicon_wins_over_brand_default(self):
+        """AC-W3: the website's OWN configured favicon must win on a
+        website page - a product-decision LOCK (design doc D5), NOT a
+        #661-regression-detection assertion.
+
+        website.layout sets `x_icon` UNCONDITIONALLY
+        (`t-set="x_icon" t-value="website.image_url(website, 'favicon')"`)
+        at `//head/*[1] position="before"` - strictly upstream of every
+        anchor candidate this fix ever considered (the fatal base `//title`
+        anchor, PR #661's `//head position="before"`, and the chosen
+        `//head/meta[last()] position="after"`). The website's own favicon
+        already wins under all three, so this assertion does NOT
+        discriminate the #661 regression - it locks the separate, already
+        settled product ruling that a website's genuine per-website favicon
+        setting must never be overridden by the brand default. A future
+        "fix" that forced the brand favicon over this setting would flip
+        this assertion - exactly what it exists to prevent.
+        """
+        response = self.url_open("/contactus")
+        self.assertEqual(response.status_code, 200)
+
+        document = html.fromstring(response.content)
+        favicons = document.xpath('//link[@rel="shortcut icon"]')
+        self.assertTrue(favicons, "a shortcut icon <link> must render")
+        href = favicons[0].get("href") or ""
+        self.assertTrue(
+            href.startswith("/web/image/website/"),
+            "the website's own configured favicon must be served, got %r" % href,
+        )
+        self.assertNotEqual(
+            href, BRAND_FAVICON,
+            "the brand default favicon must not override the website's "
+            "own configured favicon on a website-rendered page",
+        )


### PR DESCRIPTION
Close https://github.com/Viindoo/branding/issues/654

## What was wrong

`viin_brand_common`'s `web_layout` template extends `web.layout` and patched two elements **by xpath**:

```xml
<xpath expr="//title" position="attributes">…</xpath>
<xpath expr="//link[@type='image/x-icon']" position="attributes">…</xpath>
```

Core's own `WebSuite.test_check_suite` (`web/tests/test_js.py::_check_only_call`) deliberately overwrites `web.layout`'s whole `arch_db` with a minimal stand-in that has a `<head>` but **no `<title>` and no `<link>`**. That write fires `ir.ui.view`'s `arch_db` constraint, which recombines every view inheriting `web.layout` — so both xpaths fail to locate their anchor and raise:

```
ValidationError: Error while parsing or validating view:
Element '<xpath expr="//title">' cannot be located in parent view
```

Both xpaths are affected. Fixing only `//title` moves the failure to `//link`, because validation short-circuits on the first.

**Nothing is broken for a user** — the xpaths are perfectly valid against the real `web.layout`. What is broken is that `test_check_suite` ERRORs on **every** Viindoo 17 database with this module installed. That test is core's guard proving no JS test file left a stray `QUnit.only()` / `QUnit.debug()` behind — either of which silently reduces the entire ~36,000-assertion JS suite to a single test **while still printing a clean tally**. While this errors, that guard is dead fleet-wide. That is the whole reason this is worth touching branding code for.

Pre-existing since 2022-08-17 (`920e662`); unrelated to any current feature work.

## The fix

Stop patching the **elements** and set the **variables** instead, anchored on `//head` — which the stand-in does provide:

```xml
<xpath expr="//head" position="before">
    <t t-set="title"  t-value="title or 'Viindoo'"/>
    <t t-set="x_icon" t-value="x_icon or '/viin_brand/static/img/favicon.ico'"/>
</xpath>
```

Both values were only ever changing the **default** of a QWeb variable core already reads — `<title t-esc="title or 'Odoo'"/>` and `t-att-href="x_icon or '/web/static/img/favicon.ico'"`. Pre-setting them upstream leaves core to render its own single `<title>` and `<link>`, now with the Viindoo values.

Verified against core source before writing, rather than assumed:

- QWeb compiles a bare name to `values.get(name)` (`ir_qweb.py:1198-1205`), so an undefined `title` / `x_icon` is `None`, never a `NameError`.
- `t-set` mutates one shared `values` dict in document order (`ir_qweb.py:1675`), so a `t-set` placed as a previous sibling of `<head>` **is** in scope for `<head>`'s descendants.
- `_get_inheriting_views()`'s recursive CTE pulls only `mode='extension'` children (`ir_ui_view.py:603-656`), so `web.frontend_layout` (which is `primary="True"`) is unaffected — checked structurally, then confirmed by rendering `/web/login`.

Manifest `0.3.1` → `0.3.2` so existing databases reload the arch on upgrade.

## Rejected alternatives

| approach | why not |
|---|---|
| `//head` + `position="inside"` injecting a new `<title>` | core's original `<title>` is not removed → **two** `<title>` elements in production |
| `position="replace"` on `//title` | still needs `<title>` to exist in the arch being patched → identical failure against the stand-in |
| `active="False"` (core's own trick for `web.neutralize_banner`, which targets `//body`, also absent from the stand-in) | that banner is opt-in; this branding must be always-on |
| widen core's stand-in to include `<title>`/`<link>` | patching Odoo core — heavier and less local, as the issue notes |

## Evidence

Four new regression tests in `viin_brand_common/tests/test_web_layout.py`, all asserting on **rendered HTTP output** rather than the arch string — the arch shape is exactly what this change moves, so an arch-shaped assertion would be testing the implementation.

**RED**, against the unfixed template:

```
odoo.exceptions.ValidationError: Error while parsing or validating view:
Element '<xpath expr="//title">' cannot be located in parent view
0 failed, 1 error(s) of 12 tests
```

**GREEN**, after the fix — including the 8 pre-existing `test_webmanifest` tests as non-regression:

```
0 failed, 0 error(s) of 12 tests
```

The three feature-intact tests were already green before the fix, by design: they characterise the currently-correct real-render behaviour, and the bug only manifests under core's stand-in. They exist to prove the fix does not cost anything.

## The branding behaviour is unchanged — each guarantee has its own test

| guarantee | test | result |
|---|---|---|
| Title still defaults to `Viindoo`, not `Odoo` | `test_web_layout_feature_intact_default` — `/web/login` renders `<title>Viindoo</title>` | ✅ |
| Favicon still defaults to the `viin_brand` one | same test — renders `href="/viin_brand/static/img/favicon.ico"`, and asserts core's `/web/static/img/favicon.ico` does **not** leak through | ✅ |
| An explicitly supplied `title` / `x_icon` still **wins** | `…explicit_title_wins` (`/web/offline`, whose controller sets `title` before `t-call="web.layout"`, renders `Offline` not `Viindoo`) and `…explicit_icon_wins` | ✅ |
| Exactly **one** `<title>` renders | asserted via `html.count("<title>") == 1` | ✅ |

The `or`-fallback chain is unchanged by this fix, which is why precedence still works.
