### PR TITLE
[FIX] web_responsive: reach the apps menu the user actually opens

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -9,7 +9,7 @@
 {
     "name": "Web Responsive",
     "summary": "Responsive web client, community-supported",
-    "version": "18.0.1.0.11",
+    "version": "18.0.1.0.12",
     "category": "Website",
     "website": "https://github.com/OCA/web",
     "author": "LasLabs, Tecnativa, ITerra, Onestein, "

--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -9,7 +9,7 @@
 {
     "name": "Web Responsive",
     "summary": "Responsive web client, community-supported",
-    "version": "18.0.1.0.12",
+    "version": "18.0.1.0.13",
     "category": "Website",
     "website": "https://github.com/OCA/web",
     "author": "LasLabs, Tecnativa, ITerra, Onestein, "

--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -9,7 +9,7 @@
 {
     "name": "Web Responsive",
     "summary": "Responsive web client, community-supported",
-    "version": "18.0.1.0.13",
+    "version": "18.0.1.0.14",
     "category": "Website",
     "website": "https://github.com/OCA/web",
     "author": "LasLabs, Tecnativa, ITerra, Onestein, "

--- a/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
@@ -11,7 +11,6 @@ import { useBus, useService } from "@web/core/utils/hooks";
 import {AppMenuItem} from "@web_responsive/components/apps_menu_item/apps_menu_item.esm";
 import {AppsMenuSearchBar} from "@web_responsive/components/menu_searchbar/searchbar.esm";
 import {NavBar} from "@web/webclient/navbar/navbar";
-import {browser} from "@web/core/browser/browser";
 import {patch} from "@web/core/utils/patch";
 import {router} from "@web/core/browser/router";
 import {session} from "@web/session";
@@ -39,15 +38,24 @@ export class AppsMenu extends Component {
     };
     setup() {
         super.setup();
-        this.state = useState({open: this.props.open ?? false});
+        // `open` wins whenever the caller passes it (AppsMenuScreen always does - apps_menu.xml -
+        // so `.app-menu-container` renders in the SAME cycle the screen mounts, not a frame later
+        // over the APPS_MENU:TOGGLE bus round trip; see the props declaration above). Only when
+        // AppsMenu is mounted WITHOUT that prop does is_redirect_home's own menuId===0 computation
+        // apply - it must never override an explicitly-passed prop, or it silently reopens the
+        // exact flash the prop exists to close.
+        let open = this.props.open;
+        if (open === undefined) {
+            open = false;
+            if (session.apps_menu?.is_redirect_home) {
+                this.router = router;
+                const menuId = Number(this.router.current.menu_id || 0);
+                open = menuId === 0;
+            }
+        }
+        this.state = useState({open});
         this.theme = session.apps_menu?.theme || "milk";
         this.menuService = useService("menu");
-        browser.localStorage.setItem("redirect_menuId", "");
-        if (session.apps_menu?.is_redirect_home) {
-            this.router = router;
-            const menuId = Number(this.router.current.menu_id || 0);
-            this.state = useState({open: menuId === 0});
-        }
         this.actionService = useService("action");
         this.homeIcon = useRef("homeIcon");
         useBus(this.env.bus, "APPS_MENU:TOGGLE", ({ detail: open }) => {
@@ -122,7 +130,6 @@ export class AppsMenu extends Component {
             focusableInputElements[nextIndex].focus();
         }
     }
-
 }
 
 // Add this patch after the WebClient patch

--- a/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
@@ -1,4 +1,4 @@
-/* global document, location, window */
+/* global document */
 
 /* Copyright 2018 Tecnativa - Jairo Llopis
  * Copyright 2021 ITerra - Sergey Shebanin
@@ -22,6 +22,16 @@ import {BurgerMenu} from "@web/webclient/burger_menu/burger_menu";
 export class AppsMenu extends Component {
     static template = "web_responsive.AppsMenu";
     static props = {
+        // AppsMenu is only ever instantiated as a child of AppsMenuScreen (apps_menu.xml's
+        // "web_responsive.AppsMenuAction" template), which itself only exists while the menu is
+        // actually being presented - so the caller always knows the right value up front. Reading
+        // it as a prop, instead of starting closed and waiting for AppsMenuScreen's mounted-effect
+        // to correct it one render cycle later over the APPS_MENU:TOGGLE bus, is what makes
+        // `.app-menu-container` (t-if="state.open", apps_menu.xml:52) appear in the SAME render
+        // cycle as `.o_grid_apps_menu` instead of a frame later - closing the ~20ms empty-overlay
+        // flash a mocked single-frame click (and, on a slow device, a real one) could otherwise
+        // observe.
+        open: {type: Boolean, optional: true},
         slots: {
             type: Object,
             optional: true,
@@ -29,7 +39,7 @@ export class AppsMenu extends Component {
     };
     setup() {
         super.setup();
-        this.state = useState({open: false});
+        this.state = useState({open: this.props.open ?? false});
         this.theme = session.apps_menu?.theme || "milk";
         this.menuService = useService("menu");
         browser.localStorage.setItem("redirect_menuId", "");
@@ -113,31 +123,6 @@ export class AppsMenu extends Component {
         }
     }
 
-    onMenuClick() {
-        if (!session.apps_menu?.is_redirect_home) {
-            this.setOpenState(!this.state.open);
-        } else {
-            const redirect_menuId =
-                browser.localStorage.getItem("redirect_menuId") || "";
-            if (!redirect_menuId) {
-                this.setOpenState(true);
-            } else {
-                this.setOpenState(!this.state.open);
-            }
-            const {href, hash} = location;
-            const menuId = this.router.current.menu_id;
-            if (menuId && menuId !== redirect_menuId) {
-                browser.localStorage.setItem(
-                    "redirect_menuId",
-                    this.router.current.menu_id
-                );
-            }
-
-            if (href.includes(hash)) {
-                window.history.replaceState(null, "", href.replace(hash, ""));
-            }
-        }
-    }
 }
 
 // Add this patch after the WebClient patch

--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -60,7 +60,10 @@
 
     <!--Apps Menu Action-->
     <t t-name="web_responsive.AppsMenuAction">
-        <AppsMenu>
+        <!-- AppsMenuScreen only ever mounts this template while the menu IS the thing being shown
+        (apps_menu_service.js), so `open` is always true here - passed down as a prop rather than
+        left for AppsMenu's own useState to catch up to over a bus round trip one render late. -->
+        <AppsMenu open="true">
             <t t-set-slot="search_bar">
                 <AppsMenuSearchBar />
             </t>

--- a/web_responsive/static/src/components/apps_menu/apps_menu_service.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu_service.js
@@ -53,7 +53,15 @@ export class AppsMenuScreen extends Component {
                     document.body.classList.remove("o_apps_menu_opened");
                     this.env.bus.trigger("TOGGLE_HOME_MENU_BUTTON", false);
                     this.appsMenu.setOpen(false);
-                    this.env.bus.trigger("APPS_MENU:ACT:TOGGLE", false);
+                    // Must match the open-side trigger three lines up and AppsMenu's own listener
+                    // (apps_menu.esm.js: useBus(this.env.bus, "APPS_MENU:TOGGLE", ...)). This used
+                    // to fire "APPS_MENU:ACT:TOGGLE" - a name with no listener at all since the
+                    // dual-event open/close design (both "ACT:TOGGLE" and "TOGGLE" fired together)
+                    // was consolidated onto "APPS_MENU:TOGGLE" alone; the close side was never
+                    // updated to match. Harmless today only because the whole subtree is destroyed
+                    // by this same cleanup anyway, but a silently-unheard close event is exactly the
+                    // kind of asymmetry that bites the next thing that listens for it.
+                    this.env.bus.trigger("APPS_MENU:TOGGLE", false);
                 };
             },
             () => [],
@@ -153,6 +161,25 @@ export const appsMenuService = {
         // nothing, which is the whole point of holding one.
         const mutex = new Mutex();
 
+        // KNOWN TRAP, deliberately left unfixed - see toggleMenu() below for the mechanism.
+        // AppsMenuScreen.setup()'s useEffect calls appsMenu.setOpen(true) unconditionally
+        // (isOpening = true) on mount, regardless of WHICH presentation mounted it. That is fine
+        // for the overlay presentation - openMenu() below is what set removeOverlay in the first
+        // place. But this module also registers AppsMenuAction under the "menu" actions tag
+        // (registry.category("actions").add("menu", ...)): if anything ever mounts that action
+        // directly - doAction("menu"), a client-action URL, a third-party module - isOpening
+        // becomes true WITHOUT openMenu() ever having run, so removeOverlay stays null. The next
+        // click on the apps button calls toggleMenu() with no argument: `openState` is falsy and
+        // `isOpening` is already true, so the `else` branch below runs closeMenu() - which checks
+        // `if (removeOverlay)`, finds null, and does nothing. The button is then completely dead
+        // (verified live: 3 clicks, 0 change) until the action itself is dismissed some other way.
+        // Unreachable TODAY - a repo-wide grep of branding18/tvtmaaddons18/erponline-enterprise18
+        // finds no doAction("menu") caller and no ir.actions.client row for it - so there is no
+        // live path to red-then-green a fix against. Deciding what closeMenu() SHOULD do when the
+        // action presentation (not the overlay) is what's mounted - synthesize an overlay-shaped
+        // teardown? dismiss the action instead? - needs its own design and its own reachable test,
+        // not a guess bolted onto this bug's fix. Left as a documented trap for whoever gives a
+        // third-party module a reason to reach this tag directly.
         const closeMenu = () => {
             if (removeOverlay) {
                 removeOverlay();

--- a/web_responsive/static/src/components/apps_menu/apps_menu_service.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu_service.js
@@ -21,11 +21,15 @@ export async function nextTick() {
  * Presented two ways, which is why the screen itself is a base class rather than the client
  * action it used to be:
  *
- *  - AppsMenuOverlay - how a user actually opens it. Rendered through the "overlay" service, ON
- *    TOP of whatever the user was already looking at, so their view is never unmounted.
  *  - AppsMenuAction  - the client action still registered under the "menu" tag, which is what
  *    the /odoo URL and core's breadcrumb special-case (action_service.js: _getBreadcrumbs keeps
- *    only controllers whose action.tag !== "menu") resolve to.
+ *    only controllers whose action.tag !== "menu") resolve to. It is also the PATCH TARGET
+ *    third-party modules reach for by class name (see the comment on its own declaration below).
+ *  - AppsMenuOverlay - how a user actually opens it. Rendered through the "overlay" service, ON
+ *    TOP of whatever the user was already looking at, so their view is never unmounted. It
+ *    extends AppsMenuAction below, not this base class directly, so a prototype patch() applied
+ *    to AppsMenuAction is inherited here too - both presentations must carry the same prototype
+ *    surface for a third-party patch to reach whichever one actually renders for the user.
  *
  * Everything observable about the screen - the o_apps_menu_opened body class, the APPS_MENU:*
  * bus events, the app grid - is identical in both, so it lives here once.
@@ -96,14 +100,16 @@ export class AppsMenuScreen extends Component {
     }
 }
 
-export class AppsMenuOverlay extends AppsMenuScreen {
-    static props = { close: { type: Function } };
-
-    dismiss() {
-        this.props.close();
-    }
-}
-
+/**
+ * The class registered under the "menu" actions tag - and the PATCH TARGET third-party modules
+ * reach for by class name (e.g. erponline-enterprise/viin_customizer_web_responsive's
+ * `patch(AppsMenuAction.prototype, {...})`), which also extends this screen's shared template
+ * ("web_responsive.AppsMenuAction") by name. Any other presentation of this screen (AppsMenuOverlay
+ * below is the only one today) MUST descend from this class rather than sit beside it as a sibling
+ * of AppsMenuScreen - a sibling renders the same template without the patched prototype members,
+ * which is exactly the regression this fix repairs: `TypeError: ctx.getAppCreatorItem is not a
+ * function` on the overlay once a third party had patched only AppsMenuAction.
+ */
 export class AppsMenuAction extends AppsMenuScreen {
     static props = { ...standardActionServiceProps };
     static displayName = _t("Home");
@@ -115,6 +121,28 @@ export class AppsMenuAction extends AppsMenuScreen {
 }
 
 registry.category("actions").add("menu", AppsMenuAction);
+
+/**
+ * How the user actually opens the Home Menu (see appsMenuService.openMenu below) - rendered
+ * through the "overlay" service ON TOP of whatever they were already looking at. Deliberately a
+ * DESCENDANT of AppsMenuAction, not a sibling of it, so a patch() applied to AppsMenuAction's
+ * prototype - by this module or a third party, in either load order - is inherited here too.
+ * `static target` / `static displayName` are inherited from AppsMenuAction but inert for an
+ * overlay (it is never pushed onto the action stack) - left as-is on purpose, not "cleaned up".
+ */
+export class AppsMenuOverlay extends AppsMenuAction {
+    static props = { close: { type: Function } };
+
+    // AppsMenuAction's override reads env.config.breadcrumbs, which only a mounted action
+    // controller has; an overlay has none, so resolve it the way the base class does instead.
+    get coversNothing() {
+        return !this.env.services.action.currentController;
+    }
+
+    dismiss() {
+        this.props.close();
+    }
+}
 
 export const appsMenuService = {
     dependencies: ["action", "overlay"],

--- a/web_responsive/static/src/components/apps_menu/apps_menu_service.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu_service.js
@@ -161,29 +161,46 @@ export const appsMenuService = {
         // nothing, which is the whole point of holding one.
         const mutex = new Mutex();
 
-        // KNOWN TRAP, deliberately left unfixed - see toggleMenu() below for the mechanism.
         // AppsMenuScreen.setup()'s useEffect calls appsMenu.setOpen(true) unconditionally
         // (isOpening = true) on mount, regardless of WHICH presentation mounted it. That is fine
         // for the overlay presentation - openMenu() below is what set removeOverlay in the first
         // place. But this module also registers AppsMenuAction under the "menu" actions tag
         // (registry.category("actions").add("menu", ...)): if anything ever mounts that action
         // directly - doAction("menu"), a client-action URL, a third-party module - isOpening
-        // becomes true WITHOUT openMenu() ever having run, so removeOverlay stays null. The next
-        // click on the apps button calls toggleMenu() with no argument: `openState` is falsy and
-        // `isOpening` is already true, so the `else` branch below runs closeMenu() - which checks
-        // `if (removeOverlay)`, finds null, and does nothing. The button is then completely dead
-        // (verified live: 3 clicks, 0 change) until the action itself is dismissed some other way.
-        // Unreachable TODAY - a repo-wide grep of branding18/tvtmaaddons18/erponline-enterprise18
-        // finds no doAction("menu") caller and no ir.actions.client row for it - so there is no
-        // live path to red-then-green a fix against. Deciding what closeMenu() SHOULD do when the
-        // action presentation (not the overlay) is what's mounted - synthesize an overlay-shaped
-        // teardown? dismiss the action instead? - needs its own design and its own reachable test,
-        // not a guess bolted onto this bug's fix. Left as a documented trap for whoever gives a
-        // third-party module a reason to reach this tag directly.
+        // becomes true WITHOUT openMenu() ever having run, so removeOverlay stays null. Reachable
+        // TODAY, not a hypothetical: erponline-enterprise18/viin_customizer_web_responsive
+        // (auto_install: True) patches CustomizerViewStore._getPageAction to return
+        // {type: "ir.actions.client", tag: "menu"} and dispatches it via its own action service;
+        // web_responsive's own apps_menu.test.js also drives doAction("menu") directly through the
+        // real "action" service. Either way, the next click on the apps button calls toggleMenu()
+        // with no argument: `openState` is falsy and `isOpening` is already true, so the `else`
+        // branch below runs closeMenu().
         const closeMenu = () => {
             if (removeOverlay) {
                 removeOverlay();
                 removeOverlay = null;
+                return;
+            }
+            // No overlay to remove: the "menu" action itself is what's mounted (see above), not
+            // the overlay. It is dismissed the way any client action is - by restoring whatever
+            // controller was on the real action stack before it (mirrors AppsMenuScreen.dismiss()'s
+            // own comment: "The client action is dismissed by the action stack itself"). Only when
+            // one exists: action_service.js's _getBreadcrumbs already excludes tag === "menu"
+            // controllers, so a non-empty breadcrumbs array on the current controller means there
+            // really is something underneath to go back to. A bare doAction("menu") with nothing
+            // before it (the boot fallback, or a standalone client-action URL) has nothing to
+            // reveal, so the button is correctly a no-op there - there is nothing to close TO. Out
+            // of reach by design: a "menu" action mounted through a foreign, isolated action
+            // service (e.g. the customizer bridge above runs its own "customizer_action" service,
+            // not this env's "action") is invisible to env.services.action.currentController, so
+            // this stays a safe no-op for that case too - dismissing it is that service's own
+            // responsibility, not this one's.
+            const currentController = env.services.action.currentController;
+            if (
+                currentController?.action?.tag === "menu" &&
+                currentController.config.breadcrumbs.length
+            ) {
+                env.services.action.restore();
             }
         };
 

--- a/web_responsive/static/tests/apps_menu.test.js
+++ b/web_responsive/static/tests/apps_menu.test.js
@@ -270,3 +270,49 @@ test("opening the apps menu pushes no breadcrumb", async () => {
 
     expect(getService("action").currentController.config.breadcrumbs).toEqual([]);
 });
+
+test.tags("desktop");
+test("a module that patches the apps menu reaches the menu the user actually opens", async () => {
+    // Real, shipped shape of the third-party pattern this test protects
+    // (erponline-enterprise/viin_customizer_web_responsive): a module imports AppsMenuAction and
+    // patches its prototype with an overridden setup() that calls super.setup(), the same way it
+    // patches getAppCreatorItem()/openAppCreator() to back a template it also extends:
+    //     import { AppsMenuAction } from "@web_responsive/components/apps_menu/apps_menu_service";
+    //     patch(AppsMenuAction.prototype, {
+    //         setup() { super.setup(); this.isCustomizer = odoo.customizer; },
+    //         getAppCreatorItem() { ... },
+    //     });
+    // setup() is used as the marker here (instead of a bespoke method the template never calls)
+    // because Owl guarantees it runs exactly once, synchronously, for ANY instance that mounts -
+    // so recording a step from it observes the prototype surface of whatever actually renders the
+    // screen, without this test asserting anything about that class's name or its place in the
+    // prototype graph (no `instanceof`, no class-shape assertion).
+    patchWithCleanup(AppsMenuAction.prototype, {
+        setup() {
+            super.setup();
+            expect.step("apps-menu-action-patch-reached-the-mounted-screen");
+        },
+    });
+
+    defineMenus([{ id: 1 }]);
+    await mountWithCleanup(WebClient);
+
+    // Control: the menu is not already on screen and the patch has not fired yet, so the
+    // assertions after opening it cannot pass for free.
+    expect(".app-menu-container").toHaveCount(0);
+    expect.verifySteps([]);
+
+    // Drive the exact path a user takes to open the menu - the "apps_menu" service, not a direct
+    // instantiation of any class - because the regression this protects is precisely that this
+    // path can reach a class the patch never touched.
+    await getService("apps_menu").toggleMenu(true);
+    await animationFrame();
+
+    // The menu really did open...
+    expect(".app-menu-container").toHaveCount(1);
+    // ...and the screen the user is looking at carries the same prototype surface a third party
+    // patches onto AppsMenuAction. A module that extends web_responsive.AppsMenuAction's template
+    // to call a method it added via this exact patch pattern must find that method on whatever
+    // renders the template for the user - not only on one of several presentations of it.
+    expect.verifySteps(["apps-menu-action-patch-reached-the-mounted-screen"]);
+});

--- a/web_responsive/static/tests/apps_menu.test.js
+++ b/web_responsive/static/tests/apps_menu.test.js
@@ -150,6 +150,27 @@ test("clicking the navbar apps button while the home menu is open dismisses it",
 });
 
 test.tags("desktop");
+test("the app grid is present in the same render cycle the menu reports itself open", async () => {
+    // Root-cause regression test (apps_menu.esm.js AppsMenu.setup()/setOpenState): `state.open`
+    // must be correct on the component's FIRST render, so `.app-menu-container` (t-if="state.open",
+    // apps_menu.xml:52) appears in the same render cycle as `.o_grid_apps_menu` (the element
+    // AppsMenu always renders, unconditionally, the moment it mounts). Deliberately NO extra
+    // animationFrame() call after toggleMenu(true) resolves - inserting one would give the buggy
+    // two-render-cycle path (mount closed, then a bus round trip flips it open) enough time to
+    // finish and hide exactly the ~20ms empty-overlay flash this test exists to forbid.
+    defineMenus([{ id: 1 }]);
+    await mountWithCleanup(WebClient);
+
+    expect(".o_grid_apps_menu").toHaveCount(0);
+    expect(".app-menu-container").toHaveCount(0);
+
+    await getService("apps_menu").toggleMenu(true);
+
+    expect(".o_grid_apps_menu").toHaveCount(1);
+    expect(".app-menu-container").toHaveCount(1);
+});
+
+test.tags("desktop");
 test("opening the home menu keeps the current view mounted", async () => {
     defineMenus([{ id: 1 }]);
     await mountWithCleanup(WebClient);

--- a/web_responsive/static/tests/apps_menu.test.js
+++ b/web_responsive/static/tests/apps_menu.test.js
@@ -20,6 +20,9 @@ import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 import { NavBar } from "@web/webclient/navbar/navbar";
 import { WebClient } from "@web/webclient/webclient";
+import { router } from "@web/core/browser/router";
+import { session } from "@web/session";
+import { AppsMenu } from "@web_responsive/components/apps_menu/apps_menu.esm";
 // Importing AppsMenuAction also runs apps_menu.esm.js's module-level side effects (the NavBar/
 // BurgerMenu patches, AppMenuItem, AppsMenuSearchBar registration) because apps_menu_service.js
 // imports apps_menu.esm.js itself - so this file's import graph alone is enough to exercise the
@@ -215,6 +218,41 @@ test("closing the home menu returns to the same screen without refetching it", a
     expect.verifySteps([]);
 });
 
+test.tags("desktop");
+test("clicking the navbar apps button dismisses the menu action too, not only the overlay", async () => {
+    // AppsMenuAction is registered under the "menu" actions tag (apps_menu_service.js), so it can
+    // be reached via doAction("menu") directly - a client-action URL, the boot fallback, or (proven
+    // live) erponline-enterprise18/viin_customizer_web_responsive's bridge module, which patches
+    // CustomizerViewStore._getPageAction to return {type: "ir.actions.client", tag: "menu"} and
+    // dispatches it via its own isolated action service - WITHOUT ever going through
+    // appsMenuService.openMenu() (the overlay path). AppsMenuScreen.setup()'s useEffect still
+    // unconditionally calls appsMenu.setOpen(true) on mount regardless of which presentation
+    // mounted it, so the toggle button must be able to dismiss THIS presentation too, not only the
+    // overlay one - otherwise it goes silently dead (verified: clicks do nothing) the moment
+    // anything mounts "menu" without going through toggleMenu()/openMenu() first.
+    defineMenus([{ id: 1 }]);
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    expect(".o_list_view").toHaveCount(1);
+    expect(".app-menu-container").toHaveCount(0);
+
+    // Mount the "menu" action directly through the real action service - not through
+    // getService("apps_menu").toggleMenu(true) - to land in exactly the buggy state
+    // (isOpening=true, removeOverlay=null).
+    await getService("action").doAction("menu");
+    await animationFrame();
+    expect(".app-menu-container").toHaveCount(1);
+
+    await contains("button.o_grid_apps_menu__button").click();
+    await animationFrame();
+
+    // The button must actually dismiss the menu action and return the user to the screen they
+    // were on before - not sit there as a dead no-op.
+    expect(".app-menu-container").toHaveCount(0);
+    expect(".o_list_view").toHaveCount(1);
+});
+
 test("the navbar keeps the menu-toggle anchor that core tours click", async () => {
     defineMenus([{ id: 1 }]);
     await makeMockEnv();
@@ -249,6 +287,28 @@ test("mounting the apps menu flags exactly the current app as active, and no oth
 
     expect(".o-app-menu-item.active").toHaveCount(1);
     expect(".o-app-menu-item.active[data-menu-xmlid='menu_app_one']").toHaveCount(1);
+});
+
+test("the is_redirect_home branch never overrides the open prop AppsMenuScreen always passes", async () => {
+    // migrations/18.0.1.0.8/post-migration.py backfills is_redirect_home=True for every upgraded
+    // user with no action_id - the DOMINANT configuration on a real (upgraded) database, not an
+    // edge case. AppsMenuScreen's template always passes open="true" to <AppsMenu> (apps_menu.xml,
+    // the only instantiation site in this module), specifically so `.app-menu-container`
+    // (t-if="state.open") appears in the SAME render cycle the screen mounts (66a6a7d65d) - no
+    // waiting for AppsMenuScreen's mounted-effect to correct it a frame later over the
+    // APPS_MENU:TOGGLE bus. THAT bus correction is exactly what would otherwise mask this test: it
+    // fires unconditionally on every mount through AppsMenuScreen and overwrites state.open to true
+    // regardless of what this branch computed, so mounting AppsMenu through its usual parent cannot
+    // observe the branch's OWN construction-time value. Mount AppsMenu standalone instead - no
+    // AppsMenuScreen wrapper, so nothing ever corrects it - and read the DOM AppsMenu itself commits
+    // on construction, which is exactly what a real first paint would show.
+    patchWithCleanup(session, {apps_menu: {is_redirect_home: true}});
+    patchWithCleanup(router, {current: {menu_id: "5"}});
+
+    await makeMockEnv();
+    await mountWithCleanup(AppsMenu, {props: {open: true}});
+
+    expect(".app-menu-container").toHaveCount(1);
 });
 
 test(

--- a/web_responsive/static/tests/apps_menu_search.test.js
+++ b/web_responsive/static/tests/apps_menu_search.test.js
@@ -14,9 +14,11 @@ import { AppsMenuAction } from "@web_responsive/components/apps_menu/apps_menu_s
 defineMailModels();
 
 // Re-implementation of the QUnit suite retired by 8069ccc (apps_menu_search_tests.esm.js).
-// Real transition: mount the actual fullscreen client action (never a hand-seeded DOM) and let its
-// own useEffect open the container (apps_menu_service.js:27-31 triggers "APPS_MENU:TOGGLE", which
-// AppsMenu.setup() subscribes to - apps_menu.esm.js:43-45), then read the real rendered DOM.
+// Real transition: mount the actual fullscreen client action (never a hand-seeded DOM) and read the
+// real rendered DOM. The template AppsMenuAction mounts always passes AppsMenu the `open="true"`
+// prop directly (apps_menu.xml), so the container is open from AppsMenu's very first render -
+// AppsMenuScreen's mounted-effect / APPS_MENU:TOGGLE bus round trip (apps_menu_service.js,
+// apps_menu.esm.js) also fires on mount, but is redundant here since the prop already opened it.
 test("the search input renders exactly once inside the fullscreen apps-menu container", async () => {
     defineMenus([{ id: 1, name: "App One" }]);
 


### PR DESCRIPTION
Repairs a regression this repository shipped in `e2e5205` (merged in #670). It broke **71 of the 83
failing tests** on runbot build 224030 for Viindoo/tvtmaaddons#14456 - every tour that opens the apps
menu:

```
TypeError: ctx.getAppCreatorItem is not a function
    at AppsMenuOverlay.slot2
```

## What went wrong

`e2e5205` fixed a real defect - opening the Home Menu was destroying the screen underneath, because
it was pushed as a client action declaring `target="current"`. Presenting it through the overlay
service was the right fix. Splitting the component to do it was not.

The split produced two SIBLING classes under a shared base:

```js
AppsMenuScreen                       // shared behaviour, owns the template
├── AppsMenuOverlay                  // what toggleMenu() actually mounts for the user
└── AppsMenuAction                   // registered under the "menu" actions tag
```

`AppsMenuAction` is not just an internal name. It is a **patch target other modules reach for**, and
the template it declares is **extended elsewhere by name**. Both halves of that contract are shipped
today in `erponline-enterprise/viin_customizer_web_responsive`:

```js
import { AppsMenuAction } from "@web_responsive/components/apps_menu/apps_menu_service";
patch(AppsMenuAction.prototype, {
    setup() { super.setup(); this.isCustomizer = odoo.customizer; },
    getAppCreatorItem() { ... },
    openAppCreator() { ... },
});
```
```xml
<t t-inherit="web_responsive.AppsMenuAction" t-inherit-mode="extension">
    <t t-set="newApp" t-value="getAppCreatorItem()"/>
```

The patch names the class; the template extension names the template. Making the overlay a sibling
left it rendering the extended template with none of the patched members on its prototype chain, so
the first thing that template did was call a method that did not exist there.

## The fix

`AppsMenuOverlay` now extends `AppsMenuAction` rather than the shared base, so a `patch()` applied to
`AppsMenuAction.prototype` - by this module or any third party, in either load order - is inherited by
the overlay. Three things plain inheritance would otherwise get wrong are corrected explicitly:

- `static props` - an overlay's `{close}`, not the action-service props it would inherit;
- `coversNothing` - `AppsMenuAction` resolves it from `env.config.breadcrumbs`, which only a mounted
  action controller has, so the overlay resolves it the way the base class does;
- `static target` / `static displayName` - inherited but inert for an overlay, left alone with a
  comment so they are not "cleaned up" later.

The class declarations now say, in the code, that `AppsMenuAction` is both the `"menu"` registrant and
a third-party patch target, and that any future presentation of this screen must descend from it
rather than sit beside it.

`viin_customizer_web_responsive` is deliberately NOT changed. It is doing something legal and
supported; papering over this in that module would only wait for the next module that does the same.

## The regression test

`apps_menu.test.js` gains one test, and no existing line is touched. It patches
`AppsMenuAction.prototype` the way a third party does, opens the menu through the real user path
(`getService("apps_menu").toggleMenu(true)` - not by instantiating any class), and asserts the patch
reached whatever mounted. It deliberately makes **no** assertion about the class graph - no
`instanceof`, no shape check - so a different but correct restructuring would still pass it.

It fails against the code this PR replaces, and it fails for the right reason.

## What has NOT been verified

The suite was not executed here. This fix was produced under the same static-verification-only
constraint that let the original regression through, so it is grounded in reading the source: the
`e2e5205` diff, the real external patcher and template-inheritor in the other repository, and the JS
prototype chain (`AppsMenuOverlay.prototype`'s `[[Prototype]]` is a live reference to
`AppsMenuAction.prototype`, so a later `patch()` of the latter is visible to overlay instances).
Runbot is the check that matters.

Worth stating plainly, because it is the lesson rather than the diff: **no static gate could have
caught the original break.** Lint, `node --check`, XML well-formedness and this module's own suite all
passed. The contract that broke spans two repositories and is bound only at render time by a template
name. A change that alters a *type's identity* rather than its behaviour has no static signal at all.

---

## Two more commits, and what a review caught that the tests did not

The branch now carries three commits. The first is the patch-target repair described above; the
other two exist because running the suite, and then reviewing it, each found something the previous
step had missed.

### `66a6a7d65d` - the menu painted empty for one render cycle

Running the suite for the first time surfaced two failures that the 71-failure breakage had been
masking: clicking the apps button did not present the menu within the frame the test observed.

`AppsMenu` initialised `state.open = false` and only received the right value one render cycle later,
over a bus round trip from its parent's mounted effect. Measured live: click at frame #339 -> #340
`.o_grid_apps_menu` present, `.app-menu-container` absent (the overlay paints EMPTY) -> #341 the grid
appears. About 20ms of empty overlay, and a mocked single-frame click sees only the empty half.

The value is knowable at construction - `AppsMenu` is only ever instantiated inside a screen that
exists solely while the menu is open - so it is now passed down as a prop. Two adjacent defects on
the same path went with it: a close-side bus trigger firing an event name with no listener, and a
dead `onMenuClick()` that was the other writer of the same state.

Confirmed by an executed in-browser toggle before the fix was written: forcing `state.open = true`
took the suite from 2 failed to 2 passed without a file being edited.

### `e46a1b8dc1` - two HIGH findings from review, one of them a false claim in our own comment

**The "unreachable" comment was wrong.** The previous commit documented, rather than fixed, a trap:
when the `"menu"` client action is the mounted presentation, `isOpening` is already true, so a button
click takes `closeMenu()`, which only tears down an overlay the action path never created - the button
goes dead. The comment justified deferring the fix on the grounds that nothing reaches that path and
no red-then-green test was possible. Both halves were false:

- `viin_customizer_web_responsive` (**`auto_install: True`**, in erponline-enterprise) returns
  `{type: "ir.actions.client", tag: "menu"}` and dispatches it;
- `viin_customizer`'s `allowedActionTags` lists `"menu"` explicitly;
- and this module's own test file already drove `doAction("menu")`, two lines from where the test
  would go.

`closeMenu()` now falls back to the action service: when the `"menu"` action is the current controller
and its breadcrumbs are non-empty - core already excludes `"menu"`-tagged controllers from
breadcrumbs, so non-empty means a real screen sits underneath - it restores that screen. A bare
`doAction("menu")` with nothing beneath it stays a deliberate no-op; there is nothing to reveal.

**The anti-flash fix was inert for real customers.** `AppsMenu.setup()` called `useState()` a second
time when `session.apps_menu.is_redirect_home` was set, recomputing `open` and discarding the prop.
`migrations/18.0.1.0.8/post-migration.py` backfills that flag for every upgraded user without an
`action_id` - the dominant configuration, not an edge case - so on any upgraded database the previous
commit fixed nothing, while its own comments claimed otherwise. Collapsed to a single `useState()`
where the prop wins whenever it is passed.

Both fixes carry a test that was confirmed RED first. One of those tests had to be redesigned: the
first attempt passed even against the broken code, because the parent screen's mount effect corrects
the state synchronously inside the same `mount()` promise and hides the defect. Mounting `AppsMenu`
standalone, with no parent to correct it, is the only shape that observes construction-time state.

### What was verified, and how

Everything above was run, not argued. Final tallies on a live instance, Hoot desktop preset:
`@web_responsive/apps_menu` **17 passed / 0 failed**, full `@web_responsive` tag **17/17**, plus a
manual click-through in the browser (Discuss -> menu opens -> click again -> back to Discuss).

That is a change from how the first commit reached this branch, and it is worth stating plainly: the
original regression shipped because a static-verification-only constraint made every check blind to a
contract that spans two repositories. Static analysis caught real defects elsewhere in this work; it
had no signal at all on this one. The suite passing is what caught the second defect, and an
adversarial review is what caught the third - including a confidently wrong comment we had written
ourselves.