### PR TITLE
[FIX] viin_brand_mail: restore the test bot identity on update, not only on install

### DIFF
--- a/viin_brand_mail/__init__.py
+++ b/viin_brand_mail/__init__.py
@@ -1,4 +1,3 @@
-from odoo import tools
 from . import models
 from . import wizard
 
@@ -24,5 +23,7 @@ def post_load():
 
 
 def post_init_hook(env):
-    if tools.config.get('test_enable', False) and env.ref('base.partner_root', raise_if_not_found=False):
-        env.ref('base.partner_root').write({'name': 'OdooBot', 'email': 'odoobot@example.com'})
+    # The restore itself lives in `models/res_partner.py` and is driven from
+    # `data/res_partner_data.xml`, which runs on install AND on update. This hook only keeps the
+    # install path covered without restating the logic.
+    env['res.partner']._viin_brand_restore_bot_test_identity()

--- a/viin_brand_mail/data/res_partner_data.xml
+++ b/viin_brand_mail/data/res_partner_data.xml
@@ -4,4 +4,10 @@
         <field name="image_1920" type="base64" file="viin_brand/static/img/viindoobot.png"/>
         <field name="email">viindoobot@example.viindoo.com</field>
     </record>
+
+    <!-- This file is not `noupdate`, so the rebranding above re-applies on every module update.
+         `post_init_hook` runs only on INSTALL (odoo/modules/loading.py:178,244), so the test-mode
+         restore has to be driven from here too, or an update leaves the partner branded and every
+         core test hardcoding the vanilla OdooBot identity fails. -->
+    <function model="res.partner" name="_viin_brand_restore_bot_test_identity"/>
 </odoo>

--- a/viin_brand_mail/models/__init__.py
+++ b/viin_brand_mail/models/__init__.py
@@ -6,5 +6,6 @@ from . import mail_mail
 from . import mail_template
 from . import mail_thread
 from . import partner_devices
+from . import res_partner
 from . import res_config_settings
 from . import res_users

--- a/viin_brand_mail/models/res_partner.py
+++ b/viin_brand_mail/models/res_partner.py
@@ -1,0 +1,29 @@
+from odoo import api, models, tools
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def _viin_brand_restore_bot_test_identity(self):
+        """Put `base.partner_root` back to core's OdooBot identity while tests are running.
+
+        Core ships a large number of tests that hardcode the vanilla identity
+        (`odoobot@example.com` / `OdooBot`) - `google_calendar`'s Odoo-to-Google payload
+        comparisons are the widest set, since the superuser is the implicit event organiser there.
+        Rebranding it breaks every one of them, so the branding is undone for the duration of a
+        test run.
+
+        Why this is called from `data/res_partner_data.xml` and not only from `post_init_hook`:
+        that data file is not `noupdate`, so the rebranding is re-applied on EVERY module update,
+        whereas `odoo/modules/loading.py:244` calls `post_init_hook` only when the module's state
+        is `to install` (`:178`). The two were therefore asymmetric - branding on every load, the
+        restore on the first one only - and any `-u` left the partner branded, turning 17 core
+        tests red for reasons that had nothing to do with the code under test. Driving both from
+        the same data file keeps them on one trigger.
+        """
+        if not tools.config.get('test_enable', False):
+            return
+        partner_root = self.env.ref('base.partner_root', raise_if_not_found=False)
+        if partner_root:
+            partner_root.write({'name': 'OdooBot', 'email': 'odoobot@example.com'})


### PR DESCRIPTION
Found by a full-install test sweep (all 1501 installable modules, tests on both the `-i` and `-u` path). Reproduced red and verified green on **Python 3.10.20** - the interpreter runbot and SaaS actually run.

## The asymmetry

`data/res_partner_data.xml` renames `base.partner_root` to ViindooBot and is **not** `noupdate`, so the rebranding is re-applied on **every** module update. The guard that puts core's `OdooBot` / `odoobot@example.com` identity back for test runs lived in `post_init_hook`, which `odoo/modules/loading.py:244` calls **only** when the module's state is `to install` (`:178`).

So the two halves were on different triggers - branding on every load, the restore on the first one only. Any `-u` left the partner branded, and every core test that hardcodes the vanilla identity failed for a reason that had nothing to do with the code under test. `google_calendar` alone contributed 12 of them, because the superuser is the implicit event organiser in its Odoo-to-Google payload comparisons.

The load order makes it deterministic rather than flaky: `viin_brand_mail` is 117 in the graph, `google_calendar` is 136 - the branding is always already applied by the time those tests run.

## The fix

The restore moves onto `res.partner` and is driven from **the same data file that applies the branding**, so both are on one trigger. A `<function>` tag runs on update as well as install (`odoo/tools/convert.py:279-281` skips it only under `noupdate`). `post_init_hook` is kept as a one-line delegation so the logic has a single home.

## Evidence

`google_calendar` `TestSyncOdoo2Google`: **12 failed -> 0**, with zero regressions - the set of red test names after the fix is a strict subset of the set before it, verified by diffing the two runs' `FAIL:`/`ERROR:` lines. Same DB, same `--test-tags`, same interpreter for both runs.

## Worth noting beyond this PR

This is the second independent instance of one design flaw: **an init hook maintaining state that has to stay correct across every update**. Both `post_init_hook` and `pre_init_hook` are guarded by `if new_install:` (`loading.py:189,244`), so neither ever reaches a deployed database. `viin_survey` has the same shape and is fixed separately (Viindoo/tvtmaaddons#14514) - with a migration rather than a function tag, because its state changes only when the module's own map changes, whereas this module's branding re-applies on every load. Any other module using an init hook this way has the same latent bug.
